### PR TITLE
feat(docs): add comprehensive documentation site with presets tool

### DIFF
--- a/.claude/commands/code-check.md
+++ b/.claude/commands/code-check.md
@@ -1,0 +1,164 @@
+# Pre-Commit Review
+
+You are performing a comprehensive pre-commit code review for the ngx-dev-toolbar project. This review ensures code quality, Angular best practices, and documentation accuracy before commits.
+
+## Review Scope
+
+Focus your review on:
+- **Library code**: `libs/ngx-dev-toolbar/`
+- **Demo app**: `apps/ngx-dev-toolbar-demo/`
+
+## Your Task
+
+Perform the following checks and provide a comprehensive advisory report:
+
+### 1. Angular Modernization Review
+
+Use the Task tool with subagent_type="general-purpose" to review Angular code for modern patterns:
+
+**Check for:**
+- ✅ Components use `standalone: true` (implicit, not explicitly set)
+- ✅ Components use `OnPush` change detection strategy
+- ✅ Use of `input()` and `output()` functions instead of `@Input()` and `@Output()` decorators
+- ✅ State management uses signals (`signal()`, `computed()`, `effect()`)
+- ✅ No deprecated Angular APIs (e.g., `@ViewChild` with `{ static: true }` unnecessarily)
+- ✅ Proper use of `inject()` function for dependency injection
+- ✅ No `ngClass` or `ngStyle` (use class/style bindings instead)
+- ✅ Reactive Forms over Template-driven forms where applicable
+- ❌ Old patterns like `any` types without justification
+- ❌ Manual subscriptions without proper cleanup (should use async pipe or takeUntilDestroyed)
+- ❌ Constructor-based DI when `inject()` would be cleaner
+
+**Files to review:**
+- All `.ts` files in `libs/ngx-dev-toolbar/src/`
+- All `.ts` files in `apps/ngx-dev-toolbar-demo/src/`
+- Focus on recently changed files (use git diff to identify)
+
+### 2. Documentation Verification
+
+**A. README Accuracy Check:**
+
+Compare `README.md` with actual implementation:
+1. Read `README.md`
+2. Read `libs/ngx-dev-toolbar/src/index.ts` to verify exported APIs
+3. Check that README examples match current API:
+   - Installation instructions are correct
+   - Usage examples reference correct imports
+   - Feature list matches implemented features
+   - Configuration options match actual interfaces
+4. Verify version numbers and compatibility claims
+
+**B. API Documentation Match:**
+
+If documentation site exists in `apps/documentation/`:
+1. Read API reference pages in `apps/documentation/src/app/pages/docs/`
+2. Cross-reference code examples with actual library code
+3. Verify that API signatures shown match current implementation
+4. Check that deprecated APIs are marked as such
+
+### 3. Code Quality Checks (Standard Level)
+
+**A. Remove Unnecessary Comments:**
+- ❌ Commented-out code blocks (unless marked with clear reason like "// TODO: Re-enable after v2.0")
+- ❌ Obvious comments that just repeat the code (e.g., `// Set value` above `value = x`)
+- ✅ Keep: JSDoc, complex logic explanations, important warnings
+
+**B. Debug Code:**
+- ❌ `console.log`, `console.debug`, `console.warn` (unless in error handling)
+- ❌ `debugger` statements
+- ❌ Commented debugging code
+
+**C. Type Safety:**
+- ❌ Explicit `any` types without JSDoc justification
+- ❌ `@ts-ignore` or `@ts-expect-error` without explanation
+- ✅ Proper return types on functions
+- ✅ Interface/type definitions for complex objects
+
+**D. Error Handling:**
+- ✅ Try-catch blocks where appropriate (async operations, parsing, external calls)
+- ✅ Proper error messages that help debugging
+- ❌ Empty catch blocks
+- ❌ Swallowed errors without logging
+
+**E. Accessibility:**
+- ✅ Buttons have accessible labels or aria-label
+- ✅ Form inputs have associated labels
+- ✅ Icons have aria-hidden="true" or descriptive text
+- ✅ Interactive elements are keyboard accessible
+
+### 4. Additional Quality Checks
+
+**A. Imports:**
+- ❌ Unused imports
+- ✅ Imports organized (Angular core, third-party, relative)
+- ❌ Relative imports going up more than 2 levels (use path aliases)
+
+**B. File Naming:**
+- ✅ Follows Angular style guide: `*.component.ts`, `*.service.ts`, `*.models.ts`
+- ✅ Kebab-case for file names
+- ✅ `.spec.ts` files exist alongside components/services
+
+**C. Test Coverage:**
+- For new components/services, check if `.spec.ts` file exists
+- Warn if new functionality lacks tests (but don't block)
+
+**D. Code Formatting:**
+- ✅ Consistent indentation (2 spaces)
+- ✅ No trailing whitespace
+- ✅ Files end with newline
+
+## Output Format
+
+Provide your review in this format:
+
+```
+# Pre-Commit Review Report
+
+## ✅ Passed Checks
+- Angular modernization: [X/Y files reviewed]
+- Documentation accuracy: README up to date
+- Code quality: No debug statements found
+- [other passed checks]
+
+## ⚠️  Warnings
+
+### Angular Patterns
+- `libs/ngx-dev-toolbar/src/example.component.ts:42`: Using `@Input()` decorator instead of `input()` function
+- `apps/ngx-dev-toolbar-demo/src/app/app.component.ts:15`: Manual subscription without takeUntilDestroyed
+
+### Code Quality
+- `libs/ngx-dev-toolbar/src/utils/helper.ts:23`: Commented-out code block (remove or document reason)
+- `apps/ngx-dev-toolbar-demo/src/app/feature.ts:8`: console.log statement found
+
+### Documentation
+- README.md: Feature "Presets Tool" mentioned but not found in exports
+- API docs example shows old `setOptions()` method, should be `setAvailableOptions()`
+
+### Type Safety
+- `libs/ngx-dev-toolbar/src/models/config.ts:12`: Using `any` type without justification
+
+### Tests
+- New component `PresetToolComponent` missing spec file
+
+## 📊 Summary
+
+**Total Issues Found**: X warnings
+**Files Reviewed**: Y files
+**Recommendation**: ⚠️ Review warnings before committing (advisory only)
+
+## 🎯 Actionable Items
+
+1. Update input() decorators in 2 components
+2. Remove 1 console.log statement
+3. Add justification or fix 1 any type
+4. Consider adding spec file for PresetToolComponent
+5. Update README feature list
+```
+
+## Important Notes
+
+- This is an **advisory review** - do not block the commit
+- Focus on actionable, specific feedback with file paths and line numbers
+- Prioritize issues that affect code maintainability and user experience
+- If no issues found, provide a positive summary
+- Be thorough but concise - group similar issues together

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ Thumbs.db
 .nx/workspace-data
 
 .angular
+
+# SpecKit workflow files
+.specify/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![npm version](https://badge.fury.io/js/ngx-dev-toolbar.svg)](https://www.npmjs.com/package/ngx-dev-toolbar)
 [![Downloads](https://img.shields.io/npm/dm/ngx-dev-toolbar.svg)](https://www.npmjs.com/package/ngx-dev-toolbar)
 [![License](https://img.shields.io/npm/l/ngx-dev-toolbar.svg)](https://github.com/yourusername/ngx-dev-toolbar/blob/main/LICENSE)
-[![Angular](https://img.shields.io/badge/Angular-17%2B-red)](https://angular.io/)
+[![Angular](https://img.shields.io/badge/Angular-19%2B-red)](https://angular.io/)
 [![GitHub Stars](https://img.shields.io/github/stars/alfredoperez/ngx-dev-toolbar?style=social)](https://github.com/alfredoperez/ngx-dev-toolbar)
 
 <h3>A powerful development toolbar for Angular applications that helps developers to interact with the application in a more efficient way.</h3>
@@ -63,6 +63,7 @@ No more context switching or backend dependencies - everything you need is right
 - Language Switcher
 - Permissions Tool
 - App Features Tool
+- Presets Tool
 - Network Mocker (Request Interceptor)
 - Themes `Coming Soon`
 - User Session `Coming Soon`

--- a/apps/documentation/src/app/app.routes.ts
+++ b/apps/documentation/src/app/app.routes.ts
@@ -6,4 +6,34 @@ export const routes: Routes = [
     path: '',
     component: LandingComponent,
   },
+  {
+    path: 'docs',
+    loadComponent: () => import('./pages/docs/layout/docs-layout.component').then(m => m.DocsLayoutComponent),
+    children: [
+      {
+        path: '',
+        loadComponent: () => import('./pages/docs/home/home-docs.component').then(m => m.HomeDocsComponent)
+      },
+      {
+        path: 'feature-flags',
+        loadComponent: () => import('./pages/docs/feature-flags/feature-flags-docs.component').then(m => m.FeatureFlagsDocsComponent)
+      },
+      {
+        path: 'language',
+        loadComponent: () => import('./pages/docs/language/language-docs.component').then(m => m.LanguageDocsComponent)
+      },
+      {
+        path: 'permissions',
+        loadComponent: () => import('./pages/docs/permissions/permissions-docs.component').then(m => m.PermissionsDocsComponent)
+      },
+      {
+        path: 'app-features',
+        loadComponent: () => import('./pages/docs/app-features/app-features-docs.component').then(m => m.AppFeaturesDocsComponent)
+      },
+      {
+        path: 'presets',
+        loadComponent: () => import('./pages/docs/presets/presets-docs.component').then(m => m.PresetsDocsComponent)
+      }
+    ]
+  },
 ];

--- a/apps/documentation/src/app/pages/docs/app-features/app-features-docs.component.html
+++ b/apps/documentation/src/app/pages/docs/app-features/app-features-docs.component.html
@@ -1,0 +1,54 @@
+<div class="doc-page">
+  <header class="doc-hero">
+    <h1>App Features Tool</h1>
+    <p class="tagline">Test product-level features and license tiers</p>
+  </header>
+
+  <section class="doc-section">
+    <h2>Overview</h2>
+    <p>
+      The App Features Tool allows developers to test product-level features that are typically controlled by license tiers,
+      deployment configuration, or environment settings. This enables testing premium features without changing deployment configuration.
+    </p>
+  </section>
+
+  <section class="doc-section">
+    <h2>Use Cases</h2>
+    <ul class="use-case-list">
+      <li>
+        <h3>License Tier Testing</h3>
+        <p>Test application behavior across different subscription tiers (Basic, Pro, Enterprise).</p>
+      </li>
+      <li>
+        <h3>Premium Feature Development</h3>
+        <p>Develop and test premium features without upgrading your development environment.</p>
+      </li>
+      <li>
+        <h3>Demo Preparation</h3>
+        <p>Enable all features for demonstrations without changing your environment configuration.</p>
+      </li>
+    </ul>
+  </section>
+
+  <section class="doc-section">
+    <h2>Quick Start</h2>
+    <app-code-example [example]="basicExample" />
+  </section>
+
+  <section class="doc-section">
+    <h2>API Reference</h2>
+    <app-api-reference
+      [serviceName]="'DevToolbarAppFeaturesService'"
+      [methods]="apiMethods"
+    />
+  </section>
+
+  <section class="doc-section">
+    <h2>Related Tools</h2>
+    <ul class="related-tools">
+      <li><a routerLink="/docs/feature-flags">Feature Flags Tool</a> - Test development feature toggles</li>
+      <li><a routerLink="/docs/permissions">Permissions Tool</a> - Test role-based access</li>
+      <li><a routerLink="/docs/presets">Presets Tool</a> - Save feature configurations for different tiers</li>
+    </ul>
+  </section>
+</div>

--- a/apps/documentation/src/app/pages/docs/app-features/app-features-docs.component.ts
+++ b/apps/documentation/src/app/pages/docs/app-features/app-features-docs.component.ts
@@ -1,0 +1,102 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { CodeExampleComponent } from '../../../shared/components/code-example/code-example.component';
+import { ApiReferenceComponent } from '../../../shared/components/api-reference/api-reference.component';
+import { CodeExample, ApiMethod } from '../../../shared/models/documentation.models';
+
+@Component({
+  selector: 'app-app-features-docs',
+  standalone: true,
+  imports: [CommonModule, RouterLink, CodeExampleComponent, ApiReferenceComponent],
+  templateUrl: './app-features-docs.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class AppFeaturesDocsComponent {
+  basicExample: CodeExample = {
+    language: 'typescript',
+    fileName: 'app.component.ts',
+    code: `
+import { Component, inject, signal } from '@angular/core';
+import { DevToolbarAppFeaturesService } from 'ngx-dev-toolbar';
+
+@Component({
+  selector: 'app-root',
+  template: \`
+    @if (hasAnalytics()) {
+      <app-analytics-dashboard />
+    }
+    @if (hasAdvancedReporting()) {
+      <app-advanced-reports />
+    }
+  \`
+})
+export class AppComponent {
+  private appFeaturesService = inject(DevToolbarAppFeaturesService);
+
+  hasAnalytics = signal(false);
+  hasAdvancedReporting = signal(false);
+
+  ngOnInit() {
+    // Define available app features
+    this.appFeaturesService.setAvailableOptions([
+      {
+        id: 'analytics',
+        name: 'Analytics Dashboard',
+        description: 'Advanced analytics and insights',
+        isEnabled: false,
+        isForced: false
+      },
+      {
+        id: 'advanced-reporting',
+        name: 'Advanced Reporting',
+        description: 'Export and custom reports',
+        isEnabled: false,
+        isForced: false
+      }
+    ]);
+
+    // Subscribe to forced feature values
+    this.appFeaturesService.getForcedValues().subscribe(features => {
+      const analytics = features.find(f => f.id === 'analytics');
+      const reporting = features.find(f => f.id === 'advanced-reporting');
+
+      this.hasAnalytics.set(analytics?.isEnabled || false);
+      this.hasAdvancedReporting.set(reporting?.isEnabled || false);
+    });
+  }
+}
+    `.trim(),
+    description: 'Basic setup for App Features Tool - test product-level features',
+    showLineNumbers: true
+  };
+
+  apiMethods: ApiMethod[] = [
+    {
+      name: 'setAvailableOptions',
+      signature: 'setAvailableOptions(features: DevToolbarAppFeature[]): void',
+      description: 'Defines the available application features that can be toggled in the toolbar.',
+      parameters: [
+        {
+          name: 'features',
+          type: 'DevToolbarAppFeature[]',
+          description: 'Array of product-level feature definitions'
+        }
+      ],
+      returnType: {
+        type: 'void',
+        description: 'No return value'
+      }
+    },
+    {
+      name: 'getForcedValues',
+      signature: 'getForcedValues(): Observable<DevToolbarAppFeature[]>',
+      description: 'Gets an observable of app features that have been overridden through the toolbar.',
+      parameters: [],
+      returnType: {
+        type: 'Observable<DevToolbarAppFeature[]>',
+        description: 'Observable emitting forced app feature changes'
+      }
+    }
+  ];
+}

--- a/apps/documentation/src/app/pages/docs/feature-flags/feature-flags-docs.component.html
+++ b/apps/documentation/src/app/pages/docs/feature-flags/feature-flags-docs.component.html
@@ -1,0 +1,85 @@
+<div class="doc-page">
+  <header class="doc-hero">
+    <h1>Feature Flags Tool</h1>
+    <p class="tagline">Test feature toggles without backend changes</p>
+  </header>
+
+  <section class="doc-section">
+    <h2>Overview</h2>
+    <p>
+      The Feature Flags tool allows developers to override feature flag states at runtime during development and testing.
+      This enables testing different feature combinations without modifying backend configuration or redeploying applications.
+    </p>
+  </section>
+
+  <section class="doc-section">
+    <h2>Use Cases</h2>
+    <ul class="use-case-list">
+      <li>
+        <h3>Testing New Features</h3>
+        <p>Enable experimental features during development without modifying backend feature flag configuration.</p>
+        <p class="example">Example: Test dark mode toggle without deploying backend changes</p>
+      </li>
+      <li>
+        <h3>Debugging Production Issues</h3>
+        <p>Quickly enable/disable features to isolate bugs in production-like environments.</p>
+        <p class="example">Example: Disable problematic feature to identify root cause</p>
+      </li>
+      <li>
+        <h3>Demo Preparation</h3>
+        <p>Force-enable premium features for demos without changing your environment.</p>
+        <p class="example">Example: Show all features during a client presentation</p>
+      </li>
+      <li>
+        <h3>Testing Edge Cases</h3>
+        <p>Test application behavior with different flag combinations.</p>
+        <p class="example">Example: Verify UI handles disabled features gracefully</p>
+      </li>
+    </ul>
+  </section>
+
+  <section class="doc-section">
+    <h2>Quick Start</h2>
+    <app-code-example [example]="basicExample" />
+  </section>
+
+  <section class="doc-section">
+    <h2>API Reference</h2>
+    <app-api-reference
+      [serviceName]="'DevToolbarFeatureFlagService'"
+      [methods]="apiMethods"
+      [interfaces]="apiInterfaces"
+    />
+  </section>
+
+  <section class="doc-section">
+    <h2>Advanced Usage</h2>
+    <app-code-example [example]="advancedExample" />
+
+    <h3>Best Practices</h3>
+    <ul>
+      <li>Always provide meaningful names and descriptions for feature flags</li>
+      <li>Use computed signals for reactive flag state management</li>
+      <li>Initialize flags early in application lifecycle (app initialization or root component)</li>
+      <li>Subscribe to forced values to get toolbar overrides</li>
+      <li>Persist flag state across page reloads (handled automatically by the toolbar)</li>
+    </ul>
+  </section>
+
+  <section class="doc-section">
+    <h2>Integration with State Management</h2>
+    <p>
+      The Feature Flags tool integrates seamlessly with Angular's reactive state management using signals and observables.
+      When a flag is toggled in the toolbar, your application receives the updated state through the <code>getForcedValues()</code> observable.
+    </p>
+  </section>
+
+  <section class="doc-section">
+    <h2>Related Tools</h2>
+    <ul class="related-tools">
+      <li><a routerLink="/docs/permissions">Permissions Tool</a> - Test permission-based access control</li>
+      <li><a routerLink="/docs/app-features">App Features Tool</a> - Test product-level features</li>
+      <li><a routerLink="/docs/presets">Presets Tool</a> - Save and load flag configurations</li>
+    </ul>
+  </section>
+</div>

--- a/apps/documentation/src/app/pages/docs/feature-flags/feature-flags-docs.component.ts
+++ b/apps/documentation/src/app/pages/docs/feature-flags/feature-flags-docs.component.ts
@@ -1,0 +1,188 @@
+import { Component, ChangeDetectionStrategy, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CodeExampleComponent } from '../../../shared/components/code-example/code-example.component';
+import { ApiReferenceComponent } from '../../../shared/components/api-reference/api-reference.component';
+import { CodeExample, ApiMethod, ApiInterface } from '../../../shared/models/documentation.models';
+
+@Component({
+  selector: 'app-feature-flags-docs',
+  standalone: true,
+  imports: [CommonModule, CodeExampleComponent, ApiReferenceComponent],
+  templateUrl: './feature-flags-docs.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class FeatureFlagsDocsComponent implements OnInit {
+  ngOnInit() {
+    // SEO metadata will be added later
+  }
+
+  basicExample: CodeExample = {
+    language: 'typescript',
+    fileName: 'app.component.ts',
+    code: `
+import { Component, inject, OnInit } from '@angular/core';
+import { DevToolbarFeatureFlagService } from 'ngx-dev-toolbar';
+
+@Component({
+  selector: 'app-root',
+  template: \`
+    <div>
+      @if (darkModeEnabled) {
+        <p>Dark mode is enabled!</p>
+      }
+    </div>
+  \`
+})
+export class AppComponent implements OnInit {
+  private featureFlagsService = inject(DevToolbarFeatureFlagService);
+  darkModeEnabled = false;
+
+  ngOnInit() {
+    // Define available feature flags
+    this.featureFlagsService.setAvailableOptions([
+      {
+        id: 'dark-mode',
+        name: 'Dark Mode',
+        description: 'Enable dark theme',
+        isEnabled: false,
+        isForced: false
+      },
+      {
+        id: 'new-ui',
+        name: 'New UI',
+        description: 'Enable redesigned interface',
+        isEnabled: false,
+        isForced: false
+      }
+    ]);
+
+    // Subscribe to forced values from toolbar
+    this.featureFlagsService.getForcedValues().subscribe(flags => {
+      const darkMode = flags.find(f => f.id === 'dark-mode');
+      this.darkModeEnabled = darkMode?.isEnabled || false;
+    });
+  }
+}
+    `.trim(),
+    description: 'Basic setup for Feature Flags tool - define flags and subscribe to changes',
+    showLineNumbers: true
+  };
+
+  advancedExample: CodeExample = {
+    language: 'typescript',
+    fileName: 'feature-flag.service.ts',
+    code: `
+import { Injectable, inject, signal, computed } from '@angular/core';
+import { DevToolbarFeatureFlagService } from 'ngx-dev-toolbar';
+
+@Injectable({ providedIn: 'root' })
+export class FeatureFlagService {
+  private toolbarService = inject(DevToolbarFeatureFlagService);
+
+  private flags = signal<Map<string, boolean>>(new Map());
+
+  // Computed signals for specific features
+  isDarkModeEnabled = computed(() => this.flags().get('dark-mode') ?? false);
+  isNewUIEnabled = computed(() => this.flags().get('new-ui') ?? false);
+
+  initialize(availableFlags: { id: string; name: string; defaultValue: boolean }[]) {
+    // Set available options in toolbar
+    this.toolbarService.setAvailableOptions(
+      availableFlags.map(flag => ({
+        id: flag.id,
+        name: flag.name,
+        isEnabled: flag.defaultValue,
+        isForced: false
+      }))
+    );
+
+    // Subscribe to forced values
+    this.toolbarService.getForcedValues().subscribe(forced => {
+      const flagMap = new Map<string, boolean>();
+      forced.forEach(flag => flagMap.set(flag.id, flag.isEnabled));
+      this.flags.set(flagMap);
+    });
+  }
+
+  isEnabled(flagId: string): boolean {
+    return this.flags().get(flagId) ?? false;
+  }
+}
+    `.trim(),
+    description: 'Advanced pattern using signals for reactive feature flag management',
+    showLineNumbers: true
+  };
+
+  apiMethods: ApiMethod[] = [
+    {
+      name: 'setAvailableOptions',
+      signature: 'setAvailableOptions(flags: DevToolbarFlag[]): void',
+      description: 'Defines the available feature flags that can be toggled in the toolbar.',
+      parameters: [
+        {
+          name: 'flags',
+          type: 'DevToolbarFlag[]',
+          description: 'Array of feature flag definitions with id, name, current state'
+        }
+      ],
+      returnType: {
+        type: 'void',
+        description: 'No return value'
+      },
+      example: {
+        language: 'typescript',
+        code: `
+this.featureFlagsService.setAvailableOptions([
+  { id: 'beta-feature', name: 'Beta Feature', isEnabled: false, isForced: false },
+  { id: 'experimental', name: 'Experimental Mode', isEnabled: false, isForced: false }
+]);
+        `.trim()
+      }
+    },
+    {
+      name: 'getForcedValues',
+      signature: 'getForcedValues(): Observable<DevToolbarFlag[]>',
+      description: 'Gets an observable of feature flags that have been overridden through the toolbar.',
+      parameters: [],
+      returnType: {
+        type: 'Observable<DevToolbarFlag[]>',
+        description: 'Observable emitting the array of forced feature flags whenever changes occur'
+      },
+      example: {
+        language: 'typescript',
+        code: `
+this.featureFlagsService.getForcedValues().subscribe(flags => {
+  flags.forEach(flag => {
+    console.log(\`\${flag.name}: \${flag.isEnabled}\`);
+  });
+});
+        `.trim()
+      }
+    }
+  ];
+
+  apiInterfaces: ApiInterface[] = [
+    {
+      name: 'DevToolbarFlag',
+      definition: `
+interface DevToolbarFlag {
+  id: string;
+  name: string;
+  description?: string;
+  link?: string;
+  isEnabled: boolean;
+  isForced: boolean;
+}
+      `.trim(),
+      description: 'Represents a feature flag in the developer toolbar',
+      properties: [
+        { name: 'id', type: 'string', description: 'Unique identifier for the flag' },
+        { name: 'name', type: 'string', description: 'Display name shown in the UI' },
+        { name: 'description', type: 'string', description: 'Optional description of the feature', optional: true },
+        { name: 'link', type: 'string', description: 'Optional link to documentation', optional: true },
+        { name: 'isEnabled', type: 'boolean', description: 'Whether the flag is currently enabled' },
+        { name: 'isForced', type: 'boolean', description: 'Whether the flag value has been overridden via toolbar' }
+      ]
+    }
+  ];
+}

--- a/apps/documentation/src/app/pages/docs/home/home-docs.component.html
+++ b/apps/documentation/src/app/pages/docs/home/home-docs.component.html
@@ -1,0 +1,120 @@
+<div class="doc-page">
+  <!-- Hero Section -->
+  <div class="doc-hero">
+    <h1>Getting Started</h1>
+    <p class="tagline">A comprehensive development toolbar for Angular applications</p>
+  </div>
+
+  <!-- Introduction -->
+  <section class="doc-section">
+    <h2>What is ngx-dev-toolbar?</h2>
+    <p>
+      <code>ngx-dev-toolbar</code> is a powerful Angular 19+ library that provides an interactive development toolbar
+      for testing and debugging feature flags, language switching, permissions, app features, and more - all without
+      modifying your backend or redeploying your application.
+    </p>
+  </section>
+
+  <!-- Installation -->
+  <section class="doc-section">
+    <h2>Installation</h2>
+    <p>Install the package via npm:</p>
+    <pre><code>npm install ngx-dev-toolbar</code></pre>
+  </section>
+
+  <!-- Quick Setup -->
+  <section class="doc-section">
+    <h2>Quick Setup</h2>
+    <h3>1. Import the Component</h3>
+    <p>Add the toolbar component to your app:</p>
+    <pre><code>import &#123; Component &#125; from '&#64;angular/core';
+import &#123; DevToolbarComponent &#125; from 'ngx-dev-toolbar';
+
+&#64;Component(&#123;
+  selector: 'app-root',
+  standalone: true,
+  imports: [DevToolbarComponent],
+  template: `
+    &lt;ndt-toolbar /&gt;
+    &lt;router-outlet /&gt;
+  `
+&#125;)
+export class AppComponent &#123;&#125;</code></pre>
+
+    <h3>2. Start Using the Tools</h3>
+    <p>
+      Once installed, press <code>Ctrl+Shift+D</code> to toggle the toolbar. From there, you can access all available
+      tools and start configuring your development environment.
+    </p>
+  </section>
+
+  <!-- Key Features -->
+  <section class="doc-section">
+    <h2>Key Features</h2>
+    <ul>
+      <li><strong>Feature Flags:</strong> Override feature flag states at runtime for testing different configurations</li>
+      <li><strong>Language Switcher:</strong> Test your app in different languages without changing system settings</li>
+      <li><strong>Permissions:</strong> Force grant or deny permissions to test authorization logic</li>
+      <li><strong>App Features:</strong> Toggle application features on and off for development and testing</li>
+      <li><strong>Presets:</strong> Save and restore complete toolbar configurations for different testing scenarios</li>
+    </ul>
+  </section>
+
+  <!-- Available Tools -->
+  <section class="doc-section">
+    <h2>Available Tools</h2>
+    <div class="tools-grid">
+      <div class="tool-card">
+        <h3>🚩 Feature Flags</h3>
+        <p>Override feature flags to test different application states without backend changes.</p>
+        <a routerLink="/docs/feature-flags" class="tool-link">View Documentation →</a>
+      </div>
+
+      <div class="tool-card">
+        <h3>🌍 Language Switcher</h3>
+        <p>Test multi-language support by switching between configured languages instantly.</p>
+        <a routerLink="/docs/language" class="tool-link">View Documentation →</a>
+      </div>
+
+      <div class="tool-card">
+        <h3>🔐 Permissions</h3>
+        <p>Force permissions to granted or denied states for comprehensive authorization testing.</p>
+        <a routerLink="/docs/permissions" class="tool-link">View Documentation →</a>
+      </div>
+
+      <div class="tool-card">
+        <h3>💡 App Features</h3>
+        <p>Toggle application features on and off to test feature availability scenarios.</p>
+        <a routerLink="/docs/app-features" class="tool-link">View Documentation →</a>
+      </div>
+
+      <div class="tool-card">
+        <h3>⭐ Presets</h3>
+        <p>Save and restore complete toolbar configurations for repeatable testing workflows.</p>
+        <a routerLink="/docs/presets" class="tool-link">View Documentation →</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Next Steps -->
+  <section class="doc-section">
+    <h2>Next Steps</h2>
+    <p>Explore the individual tool documentation to learn how to integrate and use each feature:</p>
+    <ul>
+      <li><a routerLink="/docs/feature-flags">Feature Flags Tool</a> - Configure and override feature flags</li>
+      <li><a routerLink="/docs/language">Language Switcher Tool</a> - Set up multi-language testing</li>
+      <li><a routerLink="/docs/permissions">Permissions Tool</a> - Test authorization scenarios</li>
+      <li><a routerLink="/docs/app-features">App Features Tool</a> - Manage feature toggles</li>
+      <li><a routerLink="/docs/presets">Presets Tool</a> - Create reusable configurations</li>
+    </ul>
+  </section>
+
+  <!-- Resources -->
+  <section class="doc-section">
+    <h2>Resources</h2>
+    <ul>
+      <li><a href="https://github.com/alfredoperez/ngx-dev-toolbar" target="_blank" rel="noopener">GitHub Repository</a></li>
+      <li><a href="https://www.npmjs.com/package/ngx-dev-toolbar" target="_blank" rel="noopener">NPM Package</a></li>
+    </ul>
+  </section>
+</div>

--- a/apps/documentation/src/app/pages/docs/home/home-docs.component.scss
+++ b/apps/documentation/src/app/pages/docs/home/home-docs.component.scss
@@ -1,0 +1,48 @@
+.tools-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.tool-card {
+  padding: 1.5rem;
+  background: rgba(99, 102, 241, 0.08);
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  border-radius: 12px;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: rgba(99, 102, 241, 0.12);
+    border-color: rgba(99, 102, 241, 0.3);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(99, 102, 241, 0.2);
+  }
+
+  h3 {
+    margin: 0 0 0.75rem 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #f9fafb;
+  }
+
+  p {
+    margin: 0 0 1rem 0;
+    line-height: 1.5;
+    color: #d1d5db;
+    font-size: 0.9375rem;
+  }
+
+  .tool-link {
+    display: inline-block;
+    color: #818cf8;
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 0.9375rem;
+    transition: color 0.2s ease;
+
+    &:hover {
+      color: #a5b4fc;
+    }
+  }
+}

--- a/apps/documentation/src/app/pages/docs/home/home-docs.component.ts
+++ b/apps/documentation/src/app/pages/docs/home/home-docs.component.ts
@@ -1,0 +1,13 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-home-docs',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  templateUrl: './home-docs.component.html',
+  styleUrls: ['./home-docs.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class HomeDocsComponent {}

--- a/apps/documentation/src/app/pages/docs/language/language-docs.component.html
+++ b/apps/documentation/src/app/pages/docs/language/language-docs.component.html
@@ -1,0 +1,62 @@
+<div class="doc-page">
+  <header class="doc-hero">
+    <h1>Language Switcher Tool</h1>
+    <p class="tagline">Test internationalization without reloading</p>
+  </header>
+
+  <section class="doc-section">
+    <h2>Overview</h2>
+    <p>
+      The Language Switcher tool allows developers to quickly switch between different languages during development and testing.
+      This enables testing translations and internationalization (i18n) without manually changing browser settings or application configuration.
+    </p>
+  </section>
+
+  <section class="doc-section">
+    <h2>Use Cases</h2>
+    <ul class="use-case-list">
+      <li>
+        <h3>Testing Translations</h3>
+        <p>Quickly verify translations across different languages without reloading the application.</p>
+      </li>
+      <li>
+        <h3>Layout Verification</h3>
+        <p>Check UI layout with different text lengths (e.g., German vs. English).</p>
+      </li>
+      <li>
+        <h3>RTL Support Testing</h3>
+        <p>Test right-to-left language support (Arabic, Hebrew) with a single click.</p>
+      </li>
+      <li>
+        <h3>Demo Scenarios</h3>
+        <p>Demonstrate multi-language support during client presentations.</p>
+      </li>
+    </ul>
+  </section>
+
+  <section class="doc-section">
+    <h2>Quick Start</h2>
+    <app-code-example [example]="basicExample" />
+  </section>
+
+  <section class="doc-section">
+    <h2>API Reference</h2>
+    <app-api-reference
+      [serviceName]="'DevToolbarLanguageService'"
+      [methods]="apiMethods"
+      [interfaces]="apiInterfaces"
+    />
+  </section>
+
+  <section class="doc-section">
+    <h2>Advanced Usage</h2>
+    <app-code-example [example]="advancedExample" />
+  </section>
+
+  <section class="doc-section">
+    <h2>Related Tools</h2>
+    <ul class="related-tools">
+      <li><a routerLink="/docs/presets">Presets Tool</a> - Save language configurations with other settings</li>
+    </ul>
+  </section>
+</div>

--- a/apps/documentation/src/app/pages/docs/language/language-docs.component.ts
+++ b/apps/documentation/src/app/pages/docs/language/language-docs.component.ts
@@ -1,0 +1,133 @@
+import { Component, ChangeDetectionStrategy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { CodeExampleComponent } from '../../../shared/components/code-example/code-example.component';
+import { ApiReferenceComponent } from '../../../shared/components/api-reference/api-reference.component';
+import { CodeExample, ApiMethod, ApiInterface } from '../../../shared/models/documentation.models';
+
+@Component({
+  selector: 'app-language-docs',
+  standalone: true,
+  imports: [CommonModule, RouterLink, CodeExampleComponent, ApiReferenceComponent],
+  templateUrl: './language-docs.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class LanguageDocsComponent implements OnInit {
+  ngOnInit() {
+    // SEO metadata will be added later
+  }
+
+  basicExample: CodeExample = {
+    language: 'typescript',
+    fileName: 'app.component.ts',
+    code: `
+import { Component, inject, OnInit } from '@angular/core';
+import { DevToolbarLanguageService } from 'ngx-dev-toolbar';
+
+@Component({
+  selector: 'app-root',
+  template: '<p>{{ "HELLO" | translate }}</p>'
+})
+export class AppComponent implements OnInit {
+  private languageService = inject(DevToolbarLanguageService);
+
+  ngOnInit() {
+    // Define available languages
+    this.languageService.setAvailableOptions([
+      { id: 'en', name: 'English' },
+      { id: 'es', name: 'Español' },
+      { id: 'fr', name: 'Français' }
+    ]);
+
+    // Subscribe to language changes from toolbar
+    this.languageService.getForcedValues().subscribe(languages => {
+      const selected = languages[0];
+      if (selected) {
+        // Update your i18n service
+        console.log('Language changed to:', selected.name);
+      }
+    });
+  }
+}
+    `.trim(),
+    description: 'Basic setup for Language Tool - define languages and handle changes',
+    showLineNumbers: true
+  };
+
+  advancedExample: CodeExample = {
+    language: 'typescript',
+    fileName: 'i18n-integration.service.ts',
+    code: `
+import { Injectable, inject } from '@angular/core';
+import { DevToolbarLanguageService } from 'ngx-dev-toolbar';
+import { TranslocoService } from '@ngneat/transloco';
+
+@Injectable({ providedIn: 'root' })
+export class I18nIntegrationService {
+  private toolbarService = inject(DevToolbarLanguageService);
+  private transloco = inject(TranslocoService);
+
+  initialize(supportedLanguages: { id: string; name: string }[]) {
+    // Configure toolbar with available languages
+    this.toolbarService.setAvailableOptions(supportedLanguages);
+
+    // Subscribe to toolbar language changes
+    this.toolbarService.getForcedValues().subscribe(languages => {
+      if (languages.length > 0) {
+        const newLang = languages[0].id;
+        this.transloco.setActiveLang(newLang);
+      }
+    });
+  }
+}
+    `.trim(),
+    description: 'Advanced integration with Transloco i18n library',
+    showLineNumbers: true
+  };
+
+  apiMethods: ApiMethod[] = [
+    {
+      name: 'setAvailableOptions',
+      signature: 'setAvailableOptions(languages: Language[]): void',
+      description: 'Defines the available languages that can be selected in the toolbar.',
+      parameters: [
+        {
+          name: 'languages',
+          type: 'Language[]',
+          description: 'Array of language objects with id and name'
+        }
+      ],
+      returnType: {
+        type: 'void',
+        description: 'No return value'
+      }
+    },
+    {
+      name: 'getForcedValues',
+      signature: 'getForcedValues(): Observable<Language[]>',
+      description: 'Gets an observable of the selected language from the toolbar.',
+      parameters: [],
+      returnType: {
+        type: 'Observable<Language[]>',
+        description: 'Observable emitting array with selected language (single item)'
+      }
+    }
+  ];
+
+  apiInterfaces: ApiInterface[] = [
+    {
+      name: 'Language',
+      definition: `
+interface Language {
+  id: string;
+  name: string;
+}
+      `.trim(),
+      description: 'Represents a language option in the developer toolbar',
+      properties: [
+        { name: 'id', type: 'string', description: 'Language code (e.g., "en", "es", "fr")' },
+        { name: 'name', type: 'string', description: 'Display name of the language' }
+      ]
+    }
+  ];
+}

--- a/apps/documentation/src/app/pages/docs/layout/docs-layout.component.html
+++ b/apps/documentation/src/app/pages/docs/layout/docs-layout.component.html
@@ -1,0 +1,7 @@
+<div class="docs-layout">
+  <app-nav-sidebar></app-nav-sidebar>
+
+  <main class="docs-content" id="main-content">
+    <router-outlet></router-outlet>
+  </main>
+</div>

--- a/apps/documentation/src/app/pages/docs/layout/docs-layout.component.scss
+++ b/apps/documentation/src/app/pages/docs/layout/docs-layout.component.scss
@@ -1,0 +1,27 @@
+.docs-layout {
+  display: flex;
+  min-height: 100vh;
+  background: #0f172a;
+}
+
+.docs-content {
+  flex: 1;
+  margin-left: 280px;
+  padding: 3rem;
+  max-width: 1200px;
+  width: 100%;
+  background: linear-gradient(180deg, #1e293b 0%, #0f172a 100%);
+  min-height: 100vh;
+
+  @media (max-width: 768px) {
+    margin-left: 0;
+    padding: 1.5rem;
+    padding-top: 4.5rem; // Account for mobile toggle button
+  }
+}
+
+@media (min-width: 769px) {
+  .docs-content {
+    margin-left: 280px;
+  }
+}

--- a/apps/documentation/src/app/pages/docs/layout/docs-layout.component.ts
+++ b/apps/documentation/src/app/pages/docs/layout/docs-layout.component.ts
@@ -1,0 +1,13 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+import { NavSidebarComponent } from '../../../shared/components/nav-sidebar/nav-sidebar.component';
+
+@Component({
+  selector: 'app-docs-layout',
+  standalone: true,
+  imports: [RouterOutlet, NavSidebarComponent],
+  templateUrl: './docs-layout.component.html',
+  styleUrls: ['./docs-layout.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class DocsLayoutComponent {}

--- a/apps/documentation/src/app/pages/docs/permissions/permissions-docs.component.html
+++ b/apps/documentation/src/app/pages/docs/permissions/permissions-docs.component.html
@@ -1,0 +1,54 @@
+<div class="doc-page">
+  <header class="doc-hero">
+    <h1>Permissions Tool</h1>
+    <p class="tagline">Test role-based access control without backend changes</p>
+  </header>
+
+  <section class="doc-section">
+    <h2>Overview</h2>
+    <p>
+      The Permissions Tool allows developers to override user permissions at runtime for testing different access control scenarios.
+      This enables testing permission-based UI and functionality without changing user roles or backend configuration.
+    </p>
+  </section>
+
+  <section class="doc-section">
+    <h2>Use Cases</h2>
+    <ul class="use-case-list">
+      <li>
+        <h3>Testing Access Control</h3>
+        <p>Verify that UI elements and features are properly hidden/shown based on permissions.</p>
+      </li>
+      <li>
+        <h3>Role Simulation</h3>
+        <p>Test application behavior as different user roles (admin, editor, viewer) without switching accounts.</p>
+      </li>
+      <li>
+        <h3>Security Testing</h3>
+        <p>Ensure restricted features are properly protected when permissions are denied.</p>
+      </li>
+    </ul>
+  </section>
+
+  <section class="doc-section">
+    <h2>Quick Start</h2>
+    <app-code-example [example]="basicExample" />
+  </section>
+
+  <section class="doc-section">
+    <h2>API Reference</h2>
+    <app-api-reference
+      [serviceName]="'DevToolbarPermissionsService'"
+      [methods]="apiMethods"
+    />
+  </section>
+
+  <section class="doc-section">
+    <h2>Related Tools</h2>
+    <ul class="related-tools">
+      <li><a routerLink="/docs/feature-flags">Feature Flags Tool</a> - Test feature toggles</li>
+      <li><a routerLink="/docs/app-features">App Features Tool</a> - Test product-level features</li>
+      <li><a routerLink="/docs/presets">Presets Tool</a> - Save permission configurations</li>
+    </ul>
+  </section>
+</div>

--- a/apps/documentation/src/app/pages/docs/permissions/permissions-docs.component.ts
+++ b/apps/documentation/src/app/pages/docs/permissions/permissions-docs.component.ts
@@ -1,0 +1,102 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { CodeExampleComponent } from '../../../shared/components/code-example/code-example.component';
+import { ApiReferenceComponent } from '../../../shared/components/api-reference/api-reference.component';
+import { CodeExample, ApiMethod } from '../../../shared/models/documentation.models';
+
+@Component({
+  selector: 'app-permissions-docs',
+  standalone: true,
+  imports: [CommonModule, RouterLink, CodeExampleComponent, ApiReferenceComponent],
+  templateUrl: './permissions-docs.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PermissionsDocsComponent {
+  basicExample: CodeExample = {
+    language: 'typescript',
+    fileName: 'app.component.ts',
+    code: `
+import { Component, inject, signal } from '@angular/core';
+import { DevToolbarPermissionsService } from 'ngx-dev-toolbar';
+
+@Component({
+  selector: 'app-root',
+  template: \`
+    @if (canEdit()) {
+      <button>Edit</button>
+    }
+    @if (canDelete()) {
+      <button>Delete</button>
+    }
+  \`
+})
+export class AppComponent {
+  private permissionsService = inject(DevToolbarPermissionsService);
+
+  canEdit = signal(false);
+  canDelete = signal(false);
+
+  ngOnInit() {
+    // Define available permissions
+    this.permissionsService.setAvailableOptions([
+      {
+        id: 'can-edit',
+        name: 'Can Edit',
+        description: 'Permission to edit records',
+        isGranted: false,
+        isForced: false
+      },
+      {
+        id: 'can-delete',
+        name: 'Can Delete',
+        description: 'Permission to delete records',
+        isGranted: false,
+        isForced: false
+      }
+    ]);
+
+    // Subscribe to forced permission values
+    this.permissionsService.getForcedValues().subscribe(permissions => {
+      const edit = permissions.find(p => p.id === 'can-edit');
+      const del = permissions.find(p => p.id === 'can-delete');
+
+      this.canEdit.set(edit?.isGranted || false);
+      this.canDelete.set(del?.isGranted || false);
+    });
+  }
+}
+    `.trim(),
+    description: 'Basic setup for Permissions Tool - define permissions and handle changes',
+    showLineNumbers: true
+  };
+
+  apiMethods: ApiMethod[] = [
+    {
+      name: 'setAvailableOptions',
+      signature: 'setAvailableOptions(permissions: DevToolbarPermission[]): void',
+      description: 'Defines the available permissions that can be overridden in the toolbar.',
+      parameters: [
+        {
+          name: 'permissions',
+          type: 'DevToolbarPermission[]',
+          description: 'Array of permission definitions'
+        }
+      ],
+      returnType: {
+        type: 'void',
+        description: 'No return value'
+      }
+    },
+    {
+      name: 'getForcedValues',
+      signature: 'getForcedValues(): Observable<DevToolbarPermission[]>',
+      description: 'Gets an observable of permissions that have been overridden through the toolbar.',
+      parameters: [],
+      returnType: {
+        type: 'Observable<DevToolbarPermission[]>',
+        description: 'Observable emitting forced permission changes'
+      }
+    }
+  ];
+}

--- a/apps/documentation/src/app/pages/docs/presets/presets-docs.component.html
+++ b/apps/documentation/src/app/pages/docs/presets/presets-docs.component.html
@@ -1,0 +1,80 @@
+<div class="doc-page">
+  <header class="doc-hero">
+    <h1>Presets Tool</h1>
+    <p class="tagline">Save and load complete toolbar configurations</p>
+  </header>
+
+  <section class="doc-section">
+    <h2>Overview</h2>
+    <p>
+      The Presets Tool allows developers to save and quickly load complete toolbar configurations.
+      A preset can include feature flags, language settings, permissions, and app features - creating a complete testing environment with a single click.
+    </p>
+  </section>
+
+  <section class="doc-section">
+    <h2>Use Cases</h2>
+    <ul class="use-case-list">
+      <li>
+        <h3>Testing Scenarios</h3>
+        <p>Save configurations for different test scenarios (Basic User, Admin, Enterprise Demo, etc.).</p>
+      </li>
+      <li>
+        <h3>Team Collaboration</h3>
+        <p>Share preset configurations with team members for consistent testing environments.</p>
+      </li>
+      <li>
+        <h3>Quick Environment Switching</h3>
+        <p>Switch between different user roles or license tiers instantly without manual configuration.</p>
+      </li>
+      <li>
+        <h3>Demo Preparation</h3>
+        <p>Create presets for different demo scenarios and switch between them seamlessly.</p>
+      </li>
+    </ul>
+  </section>
+
+  <section class="doc-section">
+    <h2>Quick Start</h2>
+    <app-code-example [example]="basicExample" />
+  </section>
+
+  <section class="doc-section">
+    <h2>Preset Configuration Structure</h2>
+    <app-code-example [example]="advancedExample" />
+  </section>
+
+  <section class="doc-section">
+    <h2>API Reference</h2>
+    <app-api-reference
+      [serviceName]="'DevToolbarPresetsService'"
+      [methods]="apiMethods"
+    />
+  </section>
+
+  <section class="doc-section">
+    <h2>How Presets Work</h2>
+    <p>
+      Presets automatically apply configurations to all other tools in the toolbar. When you load a preset:
+    </p>
+    <ol>
+      <li>Feature flags are set according to the preset's <code>featureFlags</code> configuration</li>
+      <li>Language is changed to the preset's <code>language</code> value</li>
+      <li>Permissions are granted/denied according to the preset's <code>permissions</code> configuration</li>
+      <li>App features are enabled/disabled according to the preset's <code>appFeatures</code> configuration</li>
+    </ol>
+    <p>
+      All tools listen to preset changes and update their state accordingly.
+    </p>
+  </section>
+
+  <section class="doc-section">
+    <h2>Related Tools</h2>
+    <ul class="related-tools">
+      <li><a routerLink="/docs/feature-flags">Feature Flags Tool</a> - Managed by presets</li>
+      <li><a routerLink="/docs/language">Language Tool</a> - Managed by presets</li>
+      <li><a routerLink="/docs/permissions">Permissions Tool</a> - Managed by presets</li>
+      <li><a routerLink="/docs/app-features">App Features Tool</a> - Managed by presets</li>
+    </ul>
+  </section>
+</div>

--- a/apps/documentation/src/app/pages/docs/presets/presets-docs.component.ts
+++ b/apps/documentation/src/app/pages/docs/presets/presets-docs.component.ts
@@ -1,0 +1,106 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { CodeExampleComponent } from '../../../shared/components/code-example/code-example.component';
+import { ApiReferenceComponent } from '../../../shared/components/api-reference/api-reference.component';
+import { CodeExample, ApiMethod } from '../../../shared/models/documentation.models';
+
+@Component({
+  selector: 'app-presets-docs',
+  standalone: true,
+  imports: [CommonModule, RouterLink, CodeExampleComponent, ApiReferenceComponent],
+  templateUrl: './presets-docs.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PresetsDocsComponent {
+  basicExample: CodeExample = {
+    language: 'typescript',
+    fileName: 'app.component.ts',
+    code: `
+import { Component, inject } from '@angular/core';
+import { DevToolbarPresetsService } from 'ngx-dev-toolbar';
+
+@Component({
+  selector: 'app-root',
+  template: '<router-outlet />'
+})
+export class AppComponent {
+  private presetsService = inject(DevToolbarPresetsService);
+
+  ngOnInit() {
+    // Subscribe to preset changes
+    this.presetsService.getForcedValues().subscribe(presets => {
+      console.log('Active presets:', presets);
+      // Presets automatically apply settings to all tools
+    });
+  }
+}
+    `.trim(),
+    description: 'Basic setup for Presets Tool - presets automatically apply to all tools',
+    showLineNumbers: true
+  };
+
+  advancedExample: CodeExample = {
+    language: 'typescript',
+    fileName: 'preset-creation.ts',
+    code: `
+// Create a preset programmatically
+const enterprisePreset: DevToolbarPreset = {
+  id: 'enterprise-demo',
+  name: 'Enterprise Demo',
+  description: 'All premium features enabled for demos',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  config: {
+    featureFlags: {
+      enabled: ['dark-mode', 'advanced-search'],
+      disabled: []
+    },
+    language: 'en',
+    permissions: {
+      granted: ['can-edit', 'can-delete', 'can-admin'],
+      denied: []
+    },
+    appFeatures: {
+      enabled: ['analytics', 'advanced-reporting', 'white-label'],
+      disabled: []
+    }
+  }
+};
+
+// Presets are managed through the toolbar UI
+// This example shows the data structure only
+    `.trim(),
+    description: 'Example preset configuration structure',
+    showLineNumbers: true
+  };
+
+  apiMethods: ApiMethod[] = [
+    {
+      name: 'setAvailableOptions',
+      signature: 'setAvailableOptions(presets: DevToolbarPreset[]): void',
+      description: 'Defines the available presets that can be selected in the toolbar.',
+      parameters: [
+        {
+          name: 'presets',
+          type: 'DevToolbarPreset[]',
+          description: 'Array of preset configurations'
+        }
+      ],
+      returnType: {
+        type: 'void',
+        description: 'No return value'
+      }
+    },
+    {
+      name: 'getForcedValues',
+      signature: 'getForcedValues(): Observable<DevToolbarPreset[]>',
+      description: 'Gets an observable of active presets.',
+      parameters: [],
+      returnType: {
+        type: 'Observable<DevToolbarPreset[]>',
+        description: 'Observable emitting active preset changes'
+      }
+    }
+  ];
+}

--- a/apps/documentation/src/app/pages/landing/hero/hero-section.component.html
+++ b/apps/documentation/src/app/pages/landing/hero/hero-section.component.html
@@ -64,7 +64,7 @@
         <div class="flex items-center gap-3">
           <span
             class="rounded-full bg-indigo-500/10 px-3 py-1 text-sm/6 font-semibold text-indigo-400 ring-1 ring-inset ring-indigo-500/20"
-            >Beta v0.1.0</span
+            >v1.0.5</span
           >
           <span
             class="inline-flex items-center text-sm/6 font-medium text-gray-300"
@@ -105,18 +105,18 @@
       <div class="mt-10 flex items-center gap-x-6">
         <app-get-started-button text="Install from NPM" />
         <a
+          routerLink="/docs"
+          class="text-sm/6 font-semibold text-indigo-400 hover:text-indigo-300"
+        >
+          View Documentation <span aria-hidden="true">→</span>
+        </a>
+        <a
           href="https://github.com/alfredoperez/ngx-dev-toolbar"
           target="_blank"
           class="text-sm/6 font-semibold text-white hover:text-indigo-400"
         >
-          View on GitHub <span aria-hidden="true">→</span>
+          GitHub <span aria-hidden="true">→</span>
         </a>
-        <!-- <a
-          href="#"
-          class="text-sm/6 font-semibold text-indigo-400 hover:text-indigo-300"
-        >
-          Try Live Demo <span aria-hidden="true">→</span>
-        </a> -->
       </div>
     </div>
     <div

--- a/apps/documentation/src/app/pages/landing/hero/hero-section.component.ts
+++ b/apps/documentation/src/app/pages/landing/hero/hero-section.component.ts
@@ -1,11 +1,12 @@
 import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import { GetStartedButtonComponent } from '../../../shared/components/get-started-button/get-started-button.component';
 
 @Component({
-  
+
   selector: 'app-hero-section',
   standalone: true,
-  imports: [GetStartedButtonComponent],
+  imports: [GetStartedButtonComponent, RouterLink],
   templateUrl: './hero-section.component.html',
 })
 export class HeroSectionComponent {}

--- a/apps/documentation/src/app/shared/components/api-reference/api-reference.component.html
+++ b/apps/documentation/src/app/shared/components/api-reference/api-reference.component.html
@@ -1,0 +1,151 @@
+<div class="api-reference">
+  @if (serviceName()) {
+    <h3 class="service-name">{{ serviceName() }}</h3>
+  }
+
+  @if (methods().length > 0) {
+    <div class="methods-section">
+      <h4>Methods</h4>
+      @for (method of methods(); track method.name) {
+        <div class="api-item">
+          <button
+            class="api-header"
+            (click)="toggleMethod(method.name)"
+            [attr.aria-expanded]="expandedMethods().has(method.name)"
+          >
+            <span class="method-name">{{ method.name }}</span>
+            <span class="expand-icon">
+              {{ expandedMethods().has(method.name) ? '▼' : '▶' }}
+            </span>
+          </button>
+
+          @if (expandedMethods().has(method.name)) {
+            <div class="api-details">
+              <div class="signature">
+                <code>{{ method.signature }}</code>
+              </div>
+
+              <p class="description">{{ method.description }}</p>
+
+              @if (method.parameters.length > 0) {
+                <div class="parameters">
+                  <h5>Parameters</h5>
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th>Description</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      @for (param of method.parameters; track param.name) {
+                        <tr>
+                          <td>
+                            <code>{{ param.name }}</code>
+                            @if (param.optional) {
+                              <span class="optional">(optional)</span>
+                            }
+                          </td>
+                          <td><code>{{ param.type }}</code></td>
+                          <td>
+                            {{ param.description }}
+                            @if (param.defaultValue) {
+                              <div class="default-value">Default: <code>{{ param.defaultValue }}</code></div>
+                            }
+                          </td>
+                        </tr>
+                      }
+                    </tbody>
+                  </table>
+                </div>
+              }
+
+              <div class="return-type">
+                <h5>Returns</h5>
+                <p><code>{{ method.returnType.type }}</code> - {{ method.returnType.description }}</p>
+              </div>
+
+              @if (method.example) {
+                <div class="example">
+                  <h5>Example</h5>
+                  <app-code-example [example]="method.example" />
+                </div>
+              }
+
+              @if (method.notes && method.notes.length > 0) {
+                <div class="notes">
+                  <h5>Notes</h5>
+                  <ul>
+                    @for (note of method.notes; track note) {
+                      <li>{{ note }}</li>
+                    }
+                  </ul>
+                </div>
+              }
+            </div>
+          }
+        </div>
+      }
+    </div>
+  }
+
+  @if (interfaces().length > 0) {
+    <div class="interfaces-section">
+      <h4>Interfaces</h4>
+      @for (iface of interfaces(); track iface.name) {
+        <div class="api-item">
+          <button
+            class="api-header"
+            (click)="toggleInterface(iface.name)"
+            [attr.aria-expanded]="expandedInterfaces().has(iface.name)"
+          >
+            <span class="interface-name">{{ iface.name }}</span>
+            <span class="expand-icon">
+              {{ expandedInterfaces().has(iface.name) ? '▼' : '▶' }}
+            </span>
+          </button>
+
+          @if (expandedInterfaces().has(iface.name)) {
+            <div class="api-details">
+              <p class="description">{{ iface.description }}</p>
+
+              <div class="interface-definition">
+                <pre><code>{{ iface.definition }}</code></pre>
+              </div>
+
+              @if (iface.properties.length > 0) {
+                <div class="properties">
+                  <h5>Properties</h5>
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th>Description</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      @for (prop of iface.properties; track prop.name) {
+                        <tr>
+                          <td>
+                            <code>{{ prop.name }}</code>
+                            @if (prop.optional) {
+                              <span class="optional">(optional)</span>
+                            }
+                          </td>
+                          <td><code>{{ prop.type }}</code></td>
+                          <td>{{ prop.description }}</td>
+                        </tr>
+                      }
+                    </tbody>
+                  </table>
+                </div>
+              }
+            </div>
+          }
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/apps/documentation/src/app/shared/components/api-reference/api-reference.component.scss
+++ b/apps/documentation/src/app/shared/components/api-reference/api-reference.component.scss
@@ -1,0 +1,225 @@
+.api-reference {
+  margin: 2rem 0;
+}
+
+.service-name {
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid #e0e0e0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.methods-section,
+.interfaces-section {
+  margin: 2rem 0;
+
+  h4 {
+    margin-bottom: 1rem;
+    font-size: 1.25rem;
+    font-weight: 600;
+  }
+}
+
+.api-item {
+  margin-bottom: 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.api-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 1rem;
+  background: #f5f5f5;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background: #eeeeee;
+  }
+
+  &:focus {
+    outline: 2px solid #007acc;
+    outline-offset: -2px;
+  }
+}
+
+.method-name,
+.interface-name {
+  font-family: 'Courier New', monospace;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #333;
+}
+
+.expand-icon {
+  font-size: 0.75rem;
+  color: #666;
+}
+
+.api-details {
+  padding: 1.5rem;
+  background: #fff;
+}
+
+.signature,
+.interface-definition {
+  padding: 1rem;
+  margin: 1rem 0;
+  background: #f9f9f9;
+  border-left: 4px solid #007acc;
+  border-radius: 4px;
+
+  code {
+    font-family: 'Courier New', monospace;
+    font-size: 0.875rem;
+    color: #333;
+  }
+
+  pre {
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+}
+
+.description {
+  margin: 1rem 0;
+  color: #555;
+  line-height: 1.6;
+}
+
+.parameters,
+.properties {
+  margin: 1.5rem 0;
+
+  h5 {
+    margin-bottom: 0.75rem;
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+
+    th {
+      padding: 0.75rem;
+      text-align: left;
+      background: #f5f5f5;
+      border-bottom: 2px solid #e0e0e0;
+      font-weight: 600;
+      font-size: 0.875rem;
+    }
+
+    td {
+      padding: 0.75rem;
+      border-bottom: 1px solid #e0e0e0;
+      vertical-align: top;
+
+      code {
+        padding: 0.125rem 0.375rem;
+        background: #f5f5f5;
+        border-radius: 3px;
+        font-family: 'Courier New', monospace;
+        font-size: 0.875rem;
+      }
+    }
+
+    tr:last-child td {
+      border-bottom: none;
+    }
+  }
+}
+
+.optional {
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+  color: #888;
+  font-style: italic;
+}
+
+.default-value {
+  margin-top: 0.25rem;
+  font-size: 0.875rem;
+  color: #666;
+}
+
+.return-type {
+  margin: 1.5rem 0;
+
+  h5 {
+    margin-bottom: 0.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  p {
+    margin: 0;
+    color: #555;
+
+    code {
+      padding: 0.125rem 0.375rem;
+      background: #f5f5f5;
+      border-radius: 3px;
+      font-family: 'Courier New', monospace;
+      font-size: 0.875rem;
+    }
+  }
+}
+
+.example {
+  margin: 1.5rem 0;
+
+  h5 {
+    margin-bottom: 1rem;
+    font-size: 1rem;
+    font-weight: 600;
+  }
+}
+
+.notes {
+  margin: 1.5rem 0;
+  padding: 1rem;
+  background: #fff8e1;
+  border-left: 4px solid #ffc107;
+  border-radius: 4px;
+
+  h5 {
+    margin-bottom: 0.75rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #f57f17;
+  }
+
+  ul {
+    margin: 0;
+    padding-left: 1.5rem;
+
+    li {
+      margin-bottom: 0.5rem;
+      color: #666;
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .parameters table,
+  .properties table {
+    display: block;
+    overflow-x: auto;
+  }
+
+  .api-header {
+    padding: 0.75rem;
+  }
+
+  .api-details {
+    padding: 1rem;
+  }
+}

--- a/apps/documentation/src/app/shared/components/api-reference/api-reference.component.ts
+++ b/apps/documentation/src/app/shared/components/api-reference/api-reference.component.ts
@@ -1,0 +1,45 @@
+import { Component, ChangeDetectionStrategy, input, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CodeExampleComponent } from '../code-example/code-example.component';
+import { ApiMethod, ApiInterface } from '../../models/documentation.models';
+
+@Component({
+  selector: 'app-api-reference',
+  standalone: true,
+  imports: [CommonModule, CodeExampleComponent],
+  templateUrl: './api-reference.component.html',
+  styleUrls: ['./api-reference.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ApiReferenceComponent {
+  serviceName = input<string>('');
+  methods = input<ApiMethod[]>([]);
+  interfaces = input<ApiInterface[]>([]);
+
+  expandedMethods = signal(new Set<string>());
+  expandedInterfaces = signal(new Set<string>());
+
+  toggleMethod(methodName: string) {
+    this.expandedMethods.update(methods => {
+      const newMethods = new Set(methods);
+      if (newMethods.has(methodName)) {
+        newMethods.delete(methodName);
+      } else {
+        newMethods.add(methodName);
+      }
+      return newMethods;
+    });
+  }
+
+  toggleInterface(interfaceName: string) {
+    this.expandedInterfaces.update(interfaces => {
+      const newInterfaces = new Set(interfaces);
+      if (newInterfaces.has(interfaceName)) {
+        newInterfaces.delete(interfaceName);
+      } else {
+        newInterfaces.add(interfaceName);
+      }
+      return newInterfaces;
+    });
+  }
+}

--- a/apps/documentation/src/app/shared/components/code-example/code-example.component.html
+++ b/apps/documentation/src/app/shared/components/code-example/code-example.component.html
@@ -1,0 +1,30 @@
+<div class="code-example">
+  @if (example().fileName) {
+    <div class="code-header">
+      <span class="file-name">{{ example().fileName }}</span>
+      <button
+        class="copy-button"
+        (click)="onCopy()"
+        [attr.aria-label]="copied() ? 'Copied!' : 'Copy code'"
+      >
+        @if (copied()) {
+          <span class="check-icon">✓</span> Copied!
+        } @else {
+          <span class="copy-icon">📋</span> Copy
+        }
+      </button>
+    </div>
+  }
+
+  @if (example().description) {
+    <p class="description">{{ example().description }}</p>
+  }
+
+  <div class="code-wrapper">
+    <pre [class.line-numbers]="example().showLineNumbers"><code
+      appPrismHighlight
+      [language]="example().language"
+      [attr.data-language]="example().language"
+    >{{ example().code.trim() }}</code></pre>
+  </div>
+</div>

--- a/apps/documentation/src/app/shared/components/code-example/code-example.component.scss
+++ b/apps/documentation/src/app/shared/components/code-example/code-example.component.scss
@@ -1,0 +1,107 @@
+.code-example {
+  margin: 1.5rem 0;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #1e1e1e;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.code-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  background: #2d2d2d;
+  border-bottom: 1px solid #3d3d3d;
+}
+
+.file-name {
+  font-family: 'Courier New', monospace;
+  font-size: 0.875rem;
+  color: #d4d4d4;
+}
+
+.copy-button {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  color: #d4d4d4;
+  background: transparent;
+  border: 1px solid #4d4d4d;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: #3d3d3d;
+    border-color: #5d5d5d;
+  }
+
+  &:focus {
+    outline: 2px solid #007acc;
+    outline-offset: 2px;
+  }
+}
+
+.copy-icon,
+.check-icon {
+  font-size: 1rem;
+}
+
+.description {
+  padding: 0.75rem 1rem;
+  margin: 0;
+  font-size: 0.875rem;
+  color: #d4d4d4;
+  background: #252525;
+  border-bottom: 1px solid #3d3d3d;
+}
+
+.code-wrapper {
+  overflow-x: auto;
+
+  pre {
+    margin: 0;
+    padding: 1rem;
+    background: #1e1e1e;
+    overflow-x: auto;
+
+    code {
+      font-family: 'Courier New', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+      font-size: 0.875rem;
+      line-height: 1.5;
+      color: #d4d4d4;
+    }
+  }
+
+  pre.line-numbers {
+    padding-left: 3rem;
+    position: relative;
+
+    &::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      width: 2.5rem;
+      background: #252525;
+      border-right: 1px solid #3d3d3d;
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .code-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .copy-button {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/apps/documentation/src/app/shared/components/code-example/code-example.component.ts
+++ b/apps/documentation/src/app/shared/components/code-example/code-example.component.ts
@@ -1,0 +1,30 @@
+import { Component, ChangeDetectionStrategy, input, signal, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PrismHighlightDirective } from '../../directives/prism-highlight.directive';
+import { CodeCopyService } from '../../services/code-copy.service';
+import { CodeExample } from '../../models/documentation.models';
+
+@Component({
+  selector: 'app-code-example',
+  standalone: true,
+  imports: [CommonModule, PrismHighlightDirective],
+  templateUrl: './code-example.component.html',
+  styleUrls: ['./code-example.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class CodeExampleComponent {
+  example = input.required<CodeExample>();
+
+  copied = signal(false);
+  private codeCopyService = inject(CodeCopyService);
+
+  async onCopy() {
+    const code = this.example().code.trim();
+    const success = await this.codeCopyService.copyToClipboard(code);
+
+    if (success) {
+      this.copied.set(true);
+      setTimeout(() => this.copied.set(false), 2000);
+    }
+  }
+}

--- a/apps/documentation/src/app/shared/components/nav-sidebar/nav-sidebar.component.html
+++ b/apps/documentation/src/app/shared/components/nav-sidebar/nav-sidebar.component.html
@@ -1,0 +1,50 @@
+<button
+  class="mobile-toggle"
+  (click)="toggleMobileMenu()"
+  [attr.aria-expanded]="mobileMenuOpen()"
+  aria-label="Toggle navigation menu"
+>
+  <span class="hamburger-icon">☰</span>
+</button>
+
+<nav
+  class="sidebar"
+  [class.mobile-open]="mobileMenuOpen()"
+  [attr.aria-hidden]="!mobileMenuOpen() ? 'true' : null"
+>
+  <div class="sidebar-header">
+    <h2>Documentation</h2>
+  </div>
+
+  <div class="nav-content">
+    @for (section of navSections; track section.title) {
+      <div class="nav-section">
+        <h3 class="nav-section-title">{{ section.title }}</h3>
+        <ul class="nav-list" role="navigation">
+          @for (item of section.items; track item.path) {
+            <li>
+              <a
+                [routerLink]="item.path"
+                routerLinkActive="active"
+                [routerLinkActiveOptions]="{ exact: item.path === '/docs' }"
+                (click)="closeMobileMenu()"
+                class="nav-link"
+              >
+                <ndt-icon [name]="item.icon" class="nav-icon" />
+                <span class="nav-label">{{ item.label }}</span>
+              </a>
+            </li>
+          }
+        </ul>
+      </div>
+    }
+  </div>
+</nav>
+
+@if (mobileMenuOpen()) {
+  <div
+    class="overlay"
+    (click)="closeMobileMenu()"
+    aria-label="Close navigation"
+  ></div>
+}

--- a/apps/documentation/src/app/shared/components/nav-sidebar/nav-sidebar.component.scss
+++ b/apps/documentation/src/app/shared/components/nav-sidebar/nav-sidebar.component.scss
@@ -1,0 +1,199 @@
+:host {
+  display: contents;
+}
+
+.mobile-toggle {
+  display: none;
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  z-index: 1001;
+  padding: 0.75rem 1rem;
+  background: rgba(17, 24, 39, 0.95);
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  border-radius: 8px;
+  cursor: pointer;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(8px);
+
+  &:hover {
+    background: rgba(31, 41, 55, 0.95);
+    border-color: rgba(99, 102, 241, 0.5);
+  }
+
+  &:focus {
+    outline: 2px solid #6366f1;
+    outline-offset: 2px;
+  }
+
+  .hamburger-icon {
+    font-size: 1.5rem;
+    line-height: 1;
+    color: #e5e7eb;
+  }
+}
+
+.sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 280px;
+  background: linear-gradient(180deg, #111827 0%, #1f2937 100%);
+  border-right: 1px solid rgba(99, 102, 241, 0.2);
+  overflow-y: auto;
+  transition: transform 0.3s ease;
+  z-index: 1000;
+  box-shadow: 4px 0 12px rgba(0, 0, 0, 0.3);
+
+  /* Custom scrollbar */
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: rgba(0, 0, 0, 0.2);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgba(99, 102, 241, 0.3);
+    border-radius: 4px;
+
+    &:hover {
+      background: rgba(99, 102, 241, 0.5);
+    }
+  }
+}
+
+.sidebar-header {
+  padding: 2rem 1.5rem;
+  border-bottom: 1px solid rgba(99, 102, 241, 0.2);
+  background: rgba(0, 0, 0, 0.2);
+
+  h2 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 700;
+    background: linear-gradient(135deg, #60a5fa 0%, #6366f1 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    letter-spacing: -0.02em;
+  }
+}
+
+.nav-content {
+  padding: 0.5rem 0;
+}
+
+.nav-section {
+  margin-bottom: 1.5rem;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.nav-section-title {
+  margin: 0 0 0.5rem 0;
+  padding: 0.5rem 1.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #9ca3af;
+}
+
+.nav-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 0.5rem;
+}
+
+.nav-link {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.875rem 1.25rem;
+  color: #d1d5db;
+  text-decoration: none;
+  transition: all 0.2s ease;
+  border-radius: 8px;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  margin-bottom: 0.25rem;
+
+  &:hover {
+    background: rgba(99, 102, 241, 0.15);
+    color: #e5e7eb;
+    transform: translateX(4px);
+  }
+
+  &:focus {
+    outline: 2px solid #6366f1;
+    outline-offset: 2px;
+  }
+
+  &.active {
+    background: linear-gradient(135deg, rgba(99, 102, 241, 0.2) 0%, rgba(79, 70, 229, 0.2) 100%);
+    color: #fff;
+    font-weight: 600;
+    border-left: 3px solid #6366f1;
+    box-shadow: 0 2px 8px rgba(99, 102, 241, 0.3);
+
+    .nav-icon {
+      color: #818cf8;
+    }
+  }
+}
+
+.nav-icon {
+  width: 20px;
+  height: 20px;
+  color: #9ca3af;
+  transition: color 0.2s ease;
+  flex-shrink: 0;
+}
+
+.nav-label {
+  font-size: 0.9375rem;
+  flex: 1;
+}
+
+.overlay {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .mobile-toggle {
+    display: block;
+  }
+
+  .sidebar {
+    transform: translateX(-100%);
+
+    &.mobile-open {
+      transform: translateX(0);
+    }
+  }
+
+  .overlay {
+    display: block;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(4px);
+    z-index: 999;
+  }
+}
+
+@media (min-width: 769px) {
+  .sidebar {
+    position: sticky;
+    top: 0;
+    height: 100vh;
+  }
+}

--- a/apps/documentation/src/app/shared/components/nav-sidebar/nav-sidebar.component.ts
+++ b/apps/documentation/src/app/shared/components/nav-sidebar/nav-sidebar.component.ts
@@ -1,0 +1,55 @@
+import { Component, ChangeDetectionStrategy, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink, RouterLinkActive } from '@angular/router';
+import { DevToolbarIconComponent, IconName } from 'ngx-dev-toolbar';
+import { NavItem } from '../../models/documentation.models';
+
+interface DocNavItem {
+  label: string;
+  path: string;
+  icon: IconName;
+}
+
+interface DocNavSection {
+  title: string;
+  items: DocNavItem[];
+}
+
+@Component({
+  selector: 'app-nav-sidebar',
+  standalone: true,
+  imports: [CommonModule, RouterLink, RouterLinkActive, DevToolbarIconComponent],
+  templateUrl: './nav-sidebar.component.html',
+  styleUrls: ['./nav-sidebar.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class NavSidebarComponent {
+  mobileMenuOpen = signal(false);
+
+  navSections: DocNavSection[] = [
+    {
+      title: 'Getting Started',
+      items: [
+        { label: 'Home', path: '/docs', icon: 'docs' }
+      ]
+    },
+    {
+      title: 'Tools',
+      items: [
+        { label: 'Feature Flags', path: '/docs/feature-flags', icon: 'toggle-left' },
+        { label: 'Language Switcher', path: '/docs/language', icon: 'translate' },
+        { label: 'Permissions', path: '/docs/permissions', icon: 'lock' },
+        { label: 'App Features', path: '/docs/app-features', icon: 'lightbulb' },
+        { label: 'Presets', path: '/docs/presets', icon: 'star' }
+      ]
+    }
+  ];
+
+  toggleMobileMenu() {
+    this.mobileMenuOpen.update(v => !v);
+  }
+
+  closeMobileMenu() {
+    this.mobileMenuOpen.set(false);
+  }
+}

--- a/apps/documentation/src/app/shared/directives/prism-highlight.directive.ts
+++ b/apps/documentation/src/app/shared/directives/prism-highlight.directive.ts
@@ -1,0 +1,33 @@
+import { Directive, ElementRef, input, afterNextRender, Injector } from '@angular/core';
+import Prism from 'prismjs';
+import 'prismjs/components/prism-typescript';
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-markup'; // HTML
+import 'prismjs/components/prism-css';
+import 'prismjs/components/prism-json';
+import 'prismjs/components/prism-bash';
+
+@Directive({
+  selector: '[appPrismHighlight]',
+  standalone: true
+})
+export class PrismHighlightDirective {
+  language = input<string>('typescript');
+
+  constructor(
+    private el: ElementRef,
+    private injector: Injector
+  ) {
+    afterNextRender(() => this.highlight(), { injector: this.injector });
+  }
+
+  private highlight() {
+    const lang = this.language();
+    const grammar = Prism.languages[lang];
+
+    if (grammar) {
+      const code = this.el.nativeElement.textContent;
+      this.el.nativeElement.innerHTML = Prism.highlight(code, grammar, lang);
+    }
+  }
+}

--- a/apps/documentation/src/app/shared/models/documentation.models.ts
+++ b/apps/documentation/src/app/shared/models/documentation.models.ts
@@ -1,0 +1,95 @@
+export interface NavItem {
+  label: string;
+  path: string;
+  icon?: string;
+  children?: NavItem[];
+  external?: boolean;
+}
+
+export interface CodeExample {
+  language: 'typescript' | 'javascript' | 'html' | 'css' | 'json' | 'bash';
+  code: string;
+  fileName?: string;
+  description?: string;
+  showLineNumbers?: boolean;
+  highlightLines?: number[][];
+}
+
+export interface ApiMethod {
+  name: string;
+  signature: string;
+  description: string;
+  parameters: ApiParameter[];
+  returnType: {
+    type: string;
+    description: string;
+  };
+  example?: CodeExample;
+  notes?: string[];
+}
+
+export interface ApiParameter {
+  name: string;
+  type: string;
+  description: string;
+  optional?: boolean;
+  defaultValue?: string;
+}
+
+export interface ApiInterface {
+  name: string;
+  definition: string;
+  description: string;
+  properties: ApiProperty[];
+}
+
+export interface ApiProperty {
+  name: string;
+  type: string;
+  description: string;
+  optional?: boolean;
+}
+
+export interface ToolDocumentation {
+  id: string;
+  name: string;
+  icon: string;
+  tagline: string;
+  description: string;
+  useCases: UseCase[];
+  api: {
+    serviceName: string;
+    methods: ApiMethod[];
+    interfaces: ApiInterface[];
+  };
+  examples: {
+    basic: CodeExample[];
+    advanced: CodeExample[];
+  };
+  relatedTools?: string[];
+  seo: {
+    title: string;
+    description: string;
+    keywords: string[];
+  };
+}
+
+export interface UseCase {
+  title: string;
+  description: string;
+  example?: string;
+}
+
+export interface DocPageState {
+  copiedExampleId: string | null;
+  activeTab: string | null;
+  expandedSections: Set<string>;
+  tableOfContents: TocItem[];
+}
+
+export interface TocItem {
+  title: string;
+  level: number;
+  id: string;
+  children?: TocItem[];
+}

--- a/apps/documentation/src/app/shared/services/code-copy.service.ts
+++ b/apps/documentation/src/app/shared/services/code-copy.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class CodeCopyService {
+  async copyToClipboard(text: string): Promise<boolean> {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (err) {
+      console.error('Failed to copy:', err);
+      return false;
+    }
+  }
+}

--- a/apps/documentation/src/styles.scss
+++ b/apps/documentation/src/styles.scss
@@ -3,4 +3,230 @@
 @tailwind utilities;
 
 @import 'highlight.js/styles/tokyo-night-dark.css';
+
+/* Prism.js Custom Dark Theme */
+code[class*="language-"],
+pre[class*="language-"] {
+  color: #e5e7eb;
+  background: none;
+  font-family: 'Courier New', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  font-size: 0.875rem;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  line-height: 1.5;
+  tab-size: 4;
+  hyphens: none;
+}
+
+pre[class*="language-"] {
+  padding: 1rem;
+  margin: 0.5rem 0;
+  overflow: auto;
+  border-radius: 0.375rem;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(99, 102, 241, 0.2);
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #6b7280;
+}
+
+.token.punctuation {
+  color: #9ca3af;
+}
+
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #f87171;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #34d399;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+  color: #60a5fa;
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword {
+  color: #c084fc;
+}
+
+.token.function,
+.token.class-name {
+  color: #fbbf24;
+}
+
+.token.regex,
+.token.important,
+.token.variable {
+  color: #fb923c;
+}
+
 /* You can add global styles to this file, and also import other style files */
+
+/* Documentation Page Styles */
+.doc-page {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.doc-hero {
+  margin-bottom: 3rem;
+  padding-bottom: 2rem;
+  border-bottom: 2px solid rgba(99, 102, 241, 0.3);
+
+  h1 {
+    margin: 0 0 0.5rem 0;
+    font-size: 2.5rem;
+    font-weight: 700;
+    background: linear-gradient(135deg, #60a5fa 0%, #818cf8 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    letter-spacing: -0.02em;
+  }
+
+  .tagline {
+    margin: 0;
+    font-size: 1.25rem;
+    color: #9ca3af;
+  }
+}
+
+.doc-section {
+  margin-bottom: 3rem;
+
+  h2 {
+    margin-bottom: 1rem;
+    font-size: 1.875rem;
+    font-weight: 600;
+    color: #f9fafb;
+  }
+
+  h3 {
+    margin-bottom: 0.5rem;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #f3f4f6;
+  }
+
+  p {
+    margin: 1rem 0;
+    line-height: 1.6;
+    color: #e5e7eb;
+  }
+
+  code {
+    padding: 0.125rem 0.375rem;
+    background: rgba(99, 102, 241, 0.2);
+    border-radius: 3px;
+    font-family: 'Courier New', monospace;
+    font-size: 0.875rem;
+    color: #c7d2fe;
+  }
+
+  ul, ol {
+    margin: 1rem 0;
+    padding-left: 2rem;
+
+    li {
+      margin: 0.5rem 0;
+      line-height: 1.6;
+      color: #e5e7eb;
+    }
+  }
+}
+
+.use-case-list {
+  list-style: none;
+  padding: 0;
+
+  li {
+    margin: 2rem 0;
+    padding: 1.5rem;
+    background: rgba(99, 102, 241, 0.08);
+    border-left: 4px solid #6366f1;
+    border-radius: 8px;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background: rgba(99, 102, 241, 0.12);
+      transform: translateX(4px);
+    }
+
+    h3 {
+      margin: 0 0 0.5rem 0;
+      color: #f9fafb;
+    }
+
+    p {
+      margin: 0.5rem 0;
+      color: #e5e7eb;
+    }
+
+    .example {
+      margin-top: 0.75rem;
+      padding: 0.75rem;
+      background: rgba(0, 0, 0, 0.3);
+      border-radius: 6px;
+      font-size: 0.875rem;
+      font-style: italic;
+      color: #a5b4fc;
+      border: 1px solid rgba(99, 102, 241, 0.2);
+    }
+  }
+}
+
+.related-tools {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+
+  li {
+    margin: 0;
+
+    a {
+      display: block;
+      padding: 0.75rem 1.5rem;
+      background: rgba(99, 102, 241, 0.15);
+      border: 1px solid rgba(99, 102, 241, 0.3);
+      border-radius: 8px;
+      text-decoration: none;
+      color: #818cf8;
+      transition: all 0.2s ease;
+      font-weight: 500;
+
+      &:hover {
+        background: rgba(99, 102, 241, 0.25);
+        border-color: rgba(99, 102, 241, 0.5);
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(99, 102, 241, 0.2);
+      }
+    }
+  }
+}

--- a/apps/ngx-dev-toolbar-demo/src/app/app.component.ts
+++ b/apps/ngx-dev-toolbar-demo/src/app/app.component.ts
@@ -7,6 +7,7 @@ import { TranslocoService } from '@jsverse/transloco';
 import {
   DevToolbarAppFeaturesService,
   DevToolbarComponent,
+  DevToolbarConfig,
   DevToolbarFeatureFlagService,
   DevToolbarFlag,
   DevToolbarLanguageService,
@@ -66,7 +67,7 @@ import { FeatureFlagsService } from './services/feature-flags.service';
       </main>
     </div>
     }
-    <ndt-toolbar>
+    <ndt-toolbar [config]="toolbarConfig">
       <ndt-toolbar-tool
         [options]="options"
         [icon]="'bolt'"
@@ -159,6 +160,15 @@ export class AppComponent implements OnInit {
     id: 'test',
     isBeta: true,
   } as DevToolbarWindowOptions;
+
+  public toolbarConfig: DevToolbarConfig = {
+    showLanguageTool: true,
+    showFeatureFlagsTool: true,
+    showAppFeaturesTool: true,
+    showPermissionsTool: true,
+    showPresetsTool: true,
+  };
+
   useNewLayout = toSignal(
     this.featureFlagsService.select('newDemoApplicationLayout')
   );

--- a/libs/ngx-dev-toolbar/src/components/button/button.component.scss
+++ b/libs/ngx-dev-toolbar/src/components/button/button.component.scss
@@ -4,7 +4,8 @@
   display: inline-flex;
   align-items: center;
   gap: var(--ndt-spacing-xs);
-  padding: var(--ndt-spacing-xs) var(--ndt-spacing-sm);
+  padding: var(--ndt-spacing-sm) var(--ndt-spacing-md);
+  min-height: 36px;
   border: 1px solid var(--ndt-border-primary);
   border-radius: var(--ndt-border-radius-medium);
   background: var(--ndt-bg-primary);

--- a/libs/ngx-dev-toolbar/src/components/clickable-card/clickable-card.component.scss
+++ b/libs/ngx-dev-toolbar/src/components/clickable-card/clickable-card.component.scss
@@ -1,7 +1,7 @@
 .clickable-card {
   display: flex;
   flex-direction: column;
-  gap: var(--ndt-spacing-sm);
+  gap: var(--ndt-spacing-xs);
   height: 100%;
 
   &__icon {

--- a/libs/ngx-dev-toolbar/src/components/input/input.component.ts
+++ b/libs/ngx-dev-toolbar/src/components/input/input.component.ts
@@ -36,6 +36,7 @@ import { FormsModule } from '@angular/forms';
         font-size: var(--ndt-font-size-sm);
         transition: var(--ndt-transition-default);
         box-sizing: border-box;
+        min-height: 36px;
 
         &::placeholder {
           color: var(--ndt-text-muted);

--- a/libs/ngx-dev-toolbar/src/components/select/select.component.scss
+++ b/libs/ngx-dev-toolbar/src/components/select/select.component.scss
@@ -1,6 +1,13 @@
 @use '../../styles' as devtools;
 @use 'sass:map';
 
+:host {
+  @include devtools.devtools-theme;
+
+  display: inline-block;
+  font-family: devtools.$font-family;
+}
+
 .select {
   position: relative;
   width: 100%;
@@ -18,7 +25,7 @@
   user-select: none;
   transition: var(--ndt-transition-default);
   outline: none;
-  height: 32px;
+  min-height: 36px;
   box-sizing: border-box;
 
   &:hover {
@@ -52,9 +59,11 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    line-height: 1;
+    line-height: 1.4;
     margin-right: var(--ndt-spacing-sm);
     min-width: 0;
+    display: flex;
+    align-items: center;
   }
 
   &__arrow {

--- a/libs/ngx-dev-toolbar/src/components/select/select.component.ts
+++ b/libs/ngx-dev-toolbar/src/components/select/select.component.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
+  ViewEncapsulation,
   computed,
   inject,
   input,
@@ -21,6 +22,7 @@ export interface SelectOption {
 @Component({
   selector: 'ndt-select',
   standalone: true,
+  encapsulation: ViewEncapsulation.ShadowDom,
   imports: [CommonModule, FormsModule, OverlayModule, CdkMenuModule],
   template: `
     <div

--- a/libs/ngx-dev-toolbar/src/components/window/window.component.scss
+++ b/libs/ngx-dev-toolbar/src/components/window/window.component.scss
@@ -2,8 +2,11 @@
 @use 'sass:map';
 
 :host {
+  @include devtools-theme;
+
   display: block;
   width: 100%;
+  font-family: $font-family;
 }
 
 .window {
@@ -28,6 +31,12 @@
   justify-content: space-between;
   align-items: flex-start;
 
+  h1 {
+    font-size: var(--ndt-font-size-lg);
+    line-height: 1.2;
+    margin: 0;
+  }
+
   &__title {
     display: flex;
     align-items: center;
@@ -51,11 +60,14 @@
     word-wrap: break-word;
     overflow-wrap: break-word;
     max-width: 100%;
+    line-height: 1.4;
+    margin: 0;
   }
 
   &__content {
     display: flex;
     flex-direction: column;
+    gap: var(--ndt-spacing-xs);
   }
 
   &__controls {

--- a/libs/ngx-dev-toolbar/src/components/window/window.component.ts
+++ b/libs/ngx-dev-toolbar/src/components/window/window.component.ts
@@ -1,10 +1,11 @@
-import { Component, computed, inject, input, output } from '@angular/core';
+import { Component, ViewEncapsulation, computed, inject, input, output } from '@angular/core';
 import { DevToolbarStateService } from '../../dev-toolbar-state.service';
 import { DevToolbarWindowOptions } from '../toolbar-tool/toolbar-tool.models';
 
 @Component({
   selector: 'ndt-window',
   standalone: true,
+  encapsulation: ViewEncapsulation.ShadowDom,
   template: `
     <div class="window dev-toolbar" [attr.data-theme]="theme()">
       <div class="header">

--- a/libs/ngx-dev-toolbar/src/dev-toolbar.component.scss
+++ b/libs/ngx-dev-toolbar/src/dev-toolbar.component.scss
@@ -1,6 +1,13 @@
 @use './styles' as devtools;
 @use 'sass:map';
 
+:host {
+  @include devtools.devtools-theme;
+
+  display: contents; // This makes the host transparent for layout purposes
+  font-family: devtools.$font-family;
+}
+
 .dev-toolbar {
   position: fixed;
   bottom: 0;
@@ -19,4 +26,41 @@
   &--active {
     opacity: 1;
   }
+}
+
+// Typography styles scoped within the toolbar component
+h1,
+h2,
+h3,
+h4,
+h5 {
+  font-weight: 600;
+  color: var(--ndt-text-primary);
+  margin: 0;
+}
+
+h1 {
+  font-size: var(--ndt-font-size-xl);
+}
+h2 {
+  font-size: var(--ndt-font-size-lg);
+}
+h3 {
+  font-size: var(--ndt-font-size-md);
+}
+h4 {
+  font-size: var(--ndt-font-size-sm);
+}
+h5 {
+  font-size: var(--ndt-font-size-xs);
+}
+
+hr {
+  border: 1px solid var(--ndt-border-subtle);
+  margin: 1em 0;
+}
+
+p {
+  line-height: 1.5em;
+  margin: 0;
 }

--- a/libs/ngx-dev-toolbar/src/dev-toolbar.component.ts
+++ b/libs/ngx-dev-toolbar/src/dev-toolbar.component.ts
@@ -9,35 +9,37 @@ import {
   Component,
   DestroyRef,
   OnInit,
+  ViewEncapsulation,
   inject,
-  isDevMode,
+  input,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { fromEvent } from 'rxjs';
 import { filter, throttleTime } from 'rxjs/operators';
 import { DevToolbarStateService } from './dev-toolbar-state.service';
+import { DevToolbarConfig } from './models/dev-toolbar-config.interface';
 import { DevToolbarAppFeaturesToolComponent } from './tools/app-features-tool/app-features-tool.component';
 import { DevToolbarFeatureFlagsToolComponent } from './tools/feature-flags-tool/feature-flags-tool.component';
 import { DevToolbarHomeToolComponent } from './tools/home-tool/home-tool.component';
 import { SettingsService } from './tools/home-tool/settings.service';
 import { DevToolbarLanguageToolComponent } from './tools/language-tool/language-tool.component';
-import { DevToolbarNetworkMockerToolComponent } from './tools/network-mocker-tool/network-mocker-tool.component';
 import { DevToolbarPermissionsToolComponent } from './tools/permissions-tool/permissions-tool.component';
+import { DevToolbarPresetsToolComponent } from './tools/presets-tool/presets-tool.component';
 
 @Component({
   standalone: true,
   selector: 'ndt-toolbar',
   styleUrls: ['./dev-toolbar.component.scss'],
+  encapsulation: ViewEncapsulation.ShadowDom,
   imports: [
     DevToolbarHomeToolComponent,
     DevToolbarLanguageToolComponent,
     DevToolbarFeatureFlagsToolComponent,
     DevToolbarAppFeaturesToolComponent,
-    DevToolbarNetworkMockerToolComponent,
     DevToolbarPermissionsToolComponent,
+    DevToolbarPresetsToolComponent,
   ],
   template: `
-    @if (isDevMode) {
     <div
       aria-label="Developer tools"
       role="toolbar"
@@ -48,14 +50,23 @@ import { DevToolbarPermissionsToolComponent } from './tools/permissions-tool/per
       (mouseenter)="onMouseEnter()"
     >
       <ndt-home-tool />
-      <ndt-language-tool />
-      <ndt-feature-flags-tool />
-      <ndt-app-features-tool />
-      <ndt-permissions-tool />
-      <ndt-network-mocker-tool />
+      @if (config().showLanguageTool ?? true) {
+        <ndt-language-tool />
+      }
+      @if (config().showFeatureFlagsTool ?? true) {
+        <ndt-feature-flags-tool />
+      }
+      @if (config().showAppFeaturesTool ?? true) {
+        <ndt-app-features-tool />
+      }
+      @if (config().showPermissionsTool ?? true) {
+        <ndt-permissions-tool />
+      }
+      @if (config().showPresetsTool ?? true) {
+        <ndt-presets-tool />
+      }
       <ng-content />
     </div>
-    }
   `,
   animations: [
     trigger('toolbarState', [
@@ -82,7 +93,7 @@ export class DevToolbarComponent implements OnInit {
   destroyRef = inject(DestroyRef);
   settingsService = inject(SettingsService);
 
-  isDevMode = isDevMode();
+  config = input<DevToolbarConfig>({});
 
   private keyboardShortcut = fromEvent<KeyboardEvent>(window, 'keydown')
     .pipe(

--- a/libs/ngx-dev-toolbar/src/index.ts
+++ b/libs/ngx-dev-toolbar/src/index.ts
@@ -4,13 +4,11 @@ export * from './components/toolbar-tool/toolbar-tool.component';
 export * from './components/toolbar-tool/toolbar-tool.models';
 export * from './dev-toolbar.component';
 export * from './models/dev-tools.interface';
+export * from './models/dev-toolbar-config.interface';
 export * from './tools/feature-flags-tool/feature-flags.models';
 export * from './tools/feature-flags-tool/feature-flags.service';
 export * from './tools/language-tool/language.models';
 export * from './tools/language-tool/language.service';
-export * from './tools/network-mocker-tool/network-mocker-tool.component';
-export * from './tools/network-mocker-tool/network-mocker.models';
-export * from './tools/network-mocker-tool/network-mocker.service';
 export * from './tools/app-features-tool/app-features.models';
 export * from './tools/app-features-tool/app-features.service';
 export * from './tools/app-features-tool/app-features-tool.component';
@@ -19,3 +17,8 @@ export * from './tools/app-features-tool/app-features-tool.component';
 export * from './tools/permissions-tool/permissions.models';
 export * from './tools/permissions-tool/permissions.service';
 export * from './tools/permissions-tool/permissions-tool.component';
+
+// Presets Tool
+export * from './tools/presets-tool/presets.models';
+export * from './tools/presets-tool/presets.service';
+export * from './tools/presets-tool/presets-tool.component';

--- a/libs/ngx-dev-toolbar/src/models/dev-toolbar-config.interface.ts
+++ b/libs/ngx-dev-toolbar/src/models/dev-toolbar-config.interface.ts
@@ -1,0 +1,35 @@
+/**
+ * Configuration options for the Dev Toolbar component.
+ * All tool flags are optional and default to true if not specified.
+ */
+export interface DevToolbarConfig {
+  /**
+   * Show/hide the Language tool
+   * @default true
+   */
+  showLanguageTool?: boolean;
+
+  /**
+   * Show/hide the Feature Flags tool
+   * @default true
+   */
+  showFeatureFlagsTool?: boolean;
+
+  /**
+   * Show/hide the App Features tool
+   * @default true
+   */
+  showAppFeaturesTool?: boolean;
+
+  /**
+   * Show/hide the Permissions tool
+   * @default true
+   */
+  showPermissionsTool?: boolean;
+
+  /**
+   * Show/hide the Presets tool
+   * @default true
+   */
+  showPresetsTool?: boolean;
+}

--- a/libs/ngx-dev-toolbar/src/styles.scss
+++ b/libs/ngx-dev-toolbar/src/styles.scss
@@ -203,9 +203,9 @@ $z-indices: (
   --ndt-shadow-window: #{map.get(map.get($shadow-themes, light), window)};
 
   --ndt-spacing-xs: 4px;
-  --ndt-spacing-sm: 8px;
-  --ndt-spacing-md: 16px;
-  --ndt-window-padding: 24px;
+  --ndt-spacing-sm: 6px;
+  --ndt-spacing-md: 12px;
+  --ndt-window-padding: 16px;
 
   --ndt-font-size-xs: #{map.get($font-sizes, xs)};
   --ndt-font-size-sm: #{map.get($font-sizes, sm)};
@@ -297,46 +297,5 @@ $z-indices: (
         error,
         border
       )};
-  }
-}
-
-.dev-toolbar {
-  @include devtools-theme;
-
-  // Typography styles
-  h1,
-  h2,
-  h3,
-  h4,
-  h5 {
-    font-weight: 600;
-    color: var(--ndt-text-primary);
-    margin: 0;
-  }
-
-  h1 {
-    font-size: var(--ndt-font-size-xl);
-  }
-  h2 {
-    font-size: var(--ndt-font-size-lg);
-  }
-  h3 {
-    font-size: var(--ndt-font-size-md);
-  }
-  h4 {
-    font-size: var(--ndt-font-size-sm);
-  }
-  h5 {
-    font-size: var(--ndt-font-size-xs);
-  }
-
-  hr {
-    border: 1px solid var(--ndt-border-subtle);
-    margin: 1em 0;
-  }
-
-  p {
-    line-height: 1.5em;
-    margin: 0;
   }
 }

--- a/libs/ngx-dev-toolbar/src/tools/app-features-tool/app-features-tool.component.ts
+++ b/libs/ngx-dev-toolbar/src/tools/app-features-tool/app-features-tool.component.ts
@@ -111,14 +111,14 @@ import { AppFeatureFilter, DevToolbarAppFeature } from './app-features.models';
         margin-bottom: var(--ndt-spacing-md);
 
         ndt-input {
-          flex: 0.65;
+          flex: 1;
         }
 
         .filter-wrapper {
-          flex: 0.35;
+          flex: 0 0 auto;
           display: flex;
           align-items: center;
-          gap: var(--ndt-spacing-xs);
+          gap: var(--ndt-spacing-md);
 
           .filter-icon {
             width: 18px;
@@ -128,7 +128,8 @@ import { AppFeatureFilter, DevToolbarAppFeature } from './app-features.models';
           }
 
           ndt-select {
-            flex: 1;
+            flex: 0 0 auto;
+            min-width: 180px;
           }
         }
       }

--- a/libs/ngx-dev-toolbar/src/tools/feature-flags-tool/feature-flags-internal.service.spec.ts
+++ b/libs/ngx-dev-toolbar/src/tools/feature-flags-tool/feature-flags-internal.service.spec.ts
@@ -1,0 +1,415 @@
+import { TestBed } from '@angular/core/testing';
+import { DevToolsStorageService } from '../../utils/storage.service';
+import { DevToolbarInternalFeatureFlagService } from './feature-flags-internal.service';
+import { DevToolbarFlag } from './feature-flags.models';
+
+interface ForcedFlagsState {
+  enabled: string[];
+  disabled: string[];
+}
+
+describe('DevToolbarInternalFeatureFlagService', () => {
+  let service: DevToolbarInternalFeatureFlagService;
+  let storageService: jest.Mocked<DevToolsStorageService>;
+
+  const createMockFlag = (
+    id: string,
+    name: string,
+    isEnabled: boolean = false,
+    description?: string
+  ): DevToolbarFlag => ({
+    id,
+    name,
+    description,
+    isEnabled,
+    isForced: false,
+  });
+
+  beforeEach(() => {
+    const storageServiceMock = {
+      get: jest.fn(),
+      set: jest.fn(),
+      remove: jest.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        DevToolbarInternalFeatureFlagService,
+        { provide: DevToolsStorageService, useValue: storageServiceMock },
+      ],
+    });
+
+    service = TestBed.inject(DevToolbarInternalFeatureFlagService);
+    storageService = TestBed.inject(
+      DevToolsStorageService
+    ) as jest.Mocked<DevToolsStorageService>;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('initialization', () => {
+    it('should initialize with empty flags', () => {
+      expect(service.flags()).toEqual([]);
+    });
+
+    it('should load forced flags from localStorage on initialization', () => {
+      expect(storageService.get).toHaveBeenCalledWith('feature-flags');
+    });
+
+    it('should apply forced state from localStorage after setAppFlags', () => {
+      const savedState: ForcedFlagsState = {
+        enabled: ['flag1'],
+        disabled: ['flag2'],
+      };
+      storageService.get.mockReturnValue(savedState);
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          DevToolbarInternalFeatureFlagService,
+          { provide: DevToolsStorageService, useValue: storageService },
+        ],
+      });
+      const newService = TestBed.inject(DevToolbarInternalFeatureFlagService);
+
+      const flags = [
+        createMockFlag('flag1', 'Flag 1', false),
+        createMockFlag('flag2', 'Flag 2', true),
+      ];
+      newService.setAppFlags(flags);
+
+      const result = newService.flags();
+      expect(result[0].isEnabled).toBe(true); // Forced enabled
+      expect(result[0].isForced).toBe(true);
+      expect(result[1].isEnabled).toBe(false); // Forced disabled
+      expect(result[1].isForced).toBe(true);
+    });
+  });
+
+  describe('setAppFlags', () => {
+    it('should update flags when setAppFlags is called', () => {
+      const flags = [
+        createMockFlag('flag1', 'Feature Flag 1', true),
+        createMockFlag('flag2', 'Feature Flag 2', false),
+      ];
+
+      service.setAppFlags(flags);
+
+      const result = service.flags();
+      expect(result.length).toBe(2);
+      expect(result[0].id).toBe('flag1');
+      expect(result[0].name).toBe('Feature Flag 1');
+      expect(result[1].id).toBe('flag2');
+      expect(result[1].name).toBe('Feature Flag 2');
+    });
+
+    it('should handle empty flags array', () => {
+      service.setAppFlags([]);
+
+      expect(service.flags()).toEqual([]);
+    });
+
+    it('should preserve forced state when setAppFlags is called', () => {
+      const initialFlags = [
+        createMockFlag('flag1', 'Feature Flag 1', false),
+      ];
+      service.setAppFlags(initialFlags);
+
+      service.setFlag('flag1', true);
+
+      const newFlags = [
+        createMockFlag('flag1', 'Feature Flag 1', false),
+      ];
+      service.setAppFlags(newFlags);
+
+      const result = service.flags();
+      expect(result[0].isForced).toBe(true);
+      expect(result[0].isEnabled).toBe(true);
+    });
+  });
+
+  describe('setFlag to enabled', () => {
+    beforeEach(() => {
+      const flags = [
+        createMockFlag('flag1', 'Feature Flag 1', false),
+        createMockFlag('flag2', 'Feature Flag 2', false),
+      ];
+      service.setAppFlags(flags);
+    });
+
+    it('should add flag to enabled array when isEnabled=true', () => {
+      service.setFlag('flag1', true);
+
+      const result = service.flags();
+      expect(result[0].isForced).toBe(true);
+      expect(result[0].isEnabled).toBe(true);
+    });
+
+    it('should remove flag from disabled array if present', () => {
+      service.setFlag('flag1', false);
+      let result = service.flags();
+      expect(result[0].isEnabled).toBe(false);
+
+      service.setFlag('flag1', true);
+      result = service.flags();
+      expect(result[0].isEnabled).toBe(true);
+      expect(result[0].isForced).toBe(true);
+    });
+
+    it('should persist to localStorage with key feature-flags', () => {
+      service.setFlag('flag1', true);
+
+      expect(storageService.set).toHaveBeenCalledWith('feature-flags', {
+        enabled: ['flag1'],
+        disabled: [],
+      });
+    });
+  });
+
+  describe('setFlag to disabled', () => {
+    beforeEach(() => {
+      const flags = [
+        createMockFlag('flag1', 'Feature Flag 1', true),
+        createMockFlag('flag2', 'Feature Flag 2', true),
+      ];
+      service.setAppFlags(flags);
+    });
+
+    it('should add flag to disabled array when isEnabled=false', () => {
+      service.setFlag('flag1', false);
+
+      const result = service.flags();
+      expect(result[0].isForced).toBe(true);
+      expect(result[0].isEnabled).toBe(false);
+    });
+
+    it('should remove flag from enabled array if present', () => {
+      service.setFlag('flag1', true);
+      let result = service.flags();
+      expect(result[0].isEnabled).toBe(true);
+
+      service.setFlag('flag1', false);
+      result = service.flags();
+      expect(result[0].isEnabled).toBe(false);
+      expect(result[0].isForced).toBe(true);
+    });
+
+    it('should persist to localStorage', () => {
+      service.setFlag('flag1', false);
+
+      expect(storageService.set).toHaveBeenCalledWith('feature-flags', {
+        enabled: [],
+        disabled: ['flag1'],
+      });
+    });
+  });
+
+  describe('removeFlagOverride', () => {
+    it('should remove flag from both enabled and disabled arrays', () => {
+      const flags = [
+        createMockFlag('flag1', 'Feature Flag 1', true),
+        createMockFlag('flag2', 'Feature Flag 2', false),
+      ];
+      service.setAppFlags(flags);
+
+      service.setFlag('flag1', false);
+      let result = service.flags();
+      expect(result[0].isForced).toBe(true);
+
+      service.removeFlagOverride('flag1');
+      result = service.flags();
+      expect(result[0].isForced).toBe(false);
+    });
+
+    it('should restore flag to original app state', () => {
+      // Set initial state where flag1 has natural isEnabled = true
+      const flags = [
+        createMockFlag('flag1', 'Feature Flag 1', true),
+        createMockFlag('flag2', 'Feature Flag 2', false),
+      ];
+      service.setAppFlags(flags);
+
+      // Force it to disabled
+      service.setFlag('flag1', false);
+      let result = service.flags();
+      expect(result[0].isEnabled).toBe(false);
+      expect(result[0].isForced).toBe(true);
+
+      // Remove override - should restore to natural state (true)
+      service.removeFlagOverride('flag1');
+      result = service.flags();
+      expect(result[0].isEnabled).toBe(true); // Restored to original
+      expect(result[0].isForced).toBe(false);
+    });
+
+    it('should update localStorage', () => {
+      const flags = [
+        createMockFlag('flag1', 'Feature Flag 1', true),
+        createMockFlag('flag2', 'Feature Flag 2', false),
+      ];
+      service.setAppFlags(flags);
+
+      service.setFlag('flag1', true);
+      service.setFlag('flag2', false);
+
+      service.removeFlagOverride('flag1');
+
+      expect(storageService.set).toHaveBeenCalledWith('feature-flags', {
+        enabled: [],
+        disabled: ['flag2'],
+      });
+    });
+  });
+
+  describe('getForcedFlags', () => {
+    beforeEach(() => {
+      const flags = [
+        createMockFlag('flag1', 'Feature Flag 1', true),
+        createMockFlag('flag2', 'Feature Flag 2', false),
+        createMockFlag('flag3', 'Feature Flag 3', true),
+      ];
+      service.setAppFlags(flags);
+    });
+
+    it('should return only flags with isForced=true', (done) => {
+      service.setFlag('flag1', false);
+      service.setFlag('flag3', true);
+
+      service.getForcedFlags().subscribe((forced) => {
+        expect(forced.length).toBe(2);
+        expect(forced[0].id).toBe('flag1');
+        expect(forced[0].isForced).toBe(true);
+        expect(forced[1].id).toBe('flag3');
+        expect(forced[1].isForced).toBe(true);
+        done();
+      });
+    });
+
+    it('should emit when forced state changes', (done) => {
+      let emitCount = 0;
+
+      service.getForcedFlags().subscribe((forced) => {
+        emitCount++;
+        if (emitCount === 2) {
+          expect(forced.length).toBe(1);
+          done();
+        }
+      });
+
+      service.setFlag('flag1', true);
+    });
+
+    it('should handle empty forced state', (done) => {
+      service.getForcedFlags().subscribe((forced) => {
+        expect(forced.length).toBe(0);
+        done();
+      });
+    });
+  });
+
+  describe('Preset Integration: applyPresetFlags() and getCurrentForcedState()', () => {
+    beforeEach(() => {
+      const flags = [
+        createMockFlag('flag1', 'Feature Flag 1', false),
+        createMockFlag('flag2', 'Feature Flag 2', false),
+        createMockFlag('flag3', 'Feature Flag 3', true),
+      ];
+      service.setAppFlags(flags);
+    });
+
+    it('should apply preset state and replace current forced state', () => {
+      service.setFlag('flag1', true);
+      let result = service.flags();
+      expect(result[0].isForced).toBe(true);
+
+      const presetState: ForcedFlagsState = {
+        enabled: ['flag2'],
+        disabled: ['flag3'],
+      };
+      service.applyPresetFlags(presetState);
+
+      result = service.flags();
+      expect(result[0].isForced).toBe(false); // flag1 no longer forced
+      expect(result[1].isForced).toBe(true); // flag2 now forced enabled
+      expect(result[1].isEnabled).toBe(true);
+      expect(result[2].isForced).toBe(true); // flag3 now forced disabled
+      expect(result[2].isEnabled).toBe(false);
+    });
+
+    it('should persist applied preset state to localStorage', () => {
+      const presetState: ForcedFlagsState = {
+        enabled: ['flag1'],
+        disabled: ['flag2'],
+      };
+      service.applyPresetFlags(presetState);
+
+      expect(storageService.set).toHaveBeenCalledWith(
+        'feature-flags',
+        presetState
+      );
+    });
+
+    it('should emit updated forced flags after applying preset', (done) => {
+      const presetState: ForcedFlagsState = {
+        enabled: ['flag1'],
+        disabled: [],
+      };
+
+      service.getForcedFlags().subscribe((forced) => {
+        if (forced.length === 1 && forced[0].id === 'flag1') {
+          expect(forced[0].isForced).toBe(true);
+          expect(forced[0].isEnabled).toBe(true);
+          done();
+        }
+      });
+
+      service.applyPresetFlags(presetState);
+    });
+
+    it('should handle empty preset state (clear all forced overrides)', () => {
+      service.setFlag('flag1', true);
+      service.setFlag('flag2', false);
+
+      const emptyPreset: ForcedFlagsState = {
+        enabled: [],
+        disabled: [],
+      };
+      service.applyPresetFlags(emptyPreset);
+
+      const result = service.flags();
+      expect(result[0].isForced).toBe(false);
+      expect(result[1].isForced).toBe(false);
+      expect(result[2].isForced).toBe(false);
+    });
+
+    it('getCurrentForcedState should return current ForcedFlagsState object', () => {
+      service.setFlag('flag1', true);
+      service.setFlag('flag2', false);
+
+      const currentState = service.getCurrentForcedState();
+      expect(currentState).toEqual({
+        enabled: ['flag1'],
+        disabled: ['flag2'],
+      });
+    });
+
+    it('getCurrentForcedState should return empty state when no flags forced', () => {
+      const currentState = service.getCurrentForcedState();
+      expect(currentState).toEqual({
+        enabled: [],
+        disabled: [],
+      });
+    });
+
+    it('getCurrentForcedState should match structure: { enabled: string[], disabled: string[] }', () => {
+      const result = service.getCurrentForcedState();
+
+      expect(result).toHaveProperty('enabled');
+      expect(result).toHaveProperty('disabled');
+      expect(Array.isArray(result.enabled)).toBe(true);
+      expect(Array.isArray(result.disabled)).toBe(true);
+    });
+  });
+});

--- a/libs/ngx-dev-toolbar/src/tools/feature-flags-tool/feature-flags-internal.service.ts
+++ b/libs/ngx-dev-toolbar/src/tools/feature-flags-tool/feature-flags-internal.service.ts
@@ -30,7 +30,11 @@ export class DevToolbarInternalFeatureFlagService {
       return appFlags.map((flag) => ({
         ...flag,
         isForced: enabled.includes(flag.id) || disabled.includes(flag.id),
-        isEnabled: enabled.includes(flag.id),
+        isEnabled: enabled.includes(flag.id)
+          ? true
+          : disabled.includes(flag.id)
+          ? false
+          : flag.isEnabled,
       }));
     })
   );
@@ -92,5 +96,22 @@ export class DevToolbarInternalFeatureFlagService {
     if (savedFlags) {
       this.forcedFlagsSubject.next(savedFlags);
     }
+  }
+
+  /**
+   * Apply feature flags from a preset (used by Presets Tool)
+   * This method directly sets the forced flags state without user interaction
+   */
+  applyPresetFlags(presetState: ForcedFlagsState): void {
+    this.forcedFlagsSubject.next(presetState);
+    this.storageService.set(this.STORAGE_KEY, presetState);
+  }
+
+  /**
+   * Get current forced state for saving to preset
+   * Returns the raw state of enabled and disabled flag IDs
+   */
+  getCurrentForcedState(): ForcedFlagsState {
+    return this.forcedFlagsSubject.value;
   }
 }

--- a/libs/ngx-dev-toolbar/src/tools/feature-flags-tool/feature-flags-tool.component.ts
+++ b/libs/ngx-dev-toolbar/src/tools/feature-flags-tool/feature-flags-tool.component.ts
@@ -93,14 +93,14 @@ import { DevToolbarFlag, FeatureFlagFilter } from './feature-flags.models';
         margin-bottom: var(--ndt-spacing-md);
 
         ndt-input {
-          flex: 0.65;
+          flex: 1;
         }
 
         .filter-wrapper {
-          flex: 0.35;
+          flex: 0 0 auto;
           display: flex;
           align-items: center;
-          gap: var(--ndt-spacing-xs);
+          gap: var(--ndt-spacing-md);
 
           .filter-icon {
             width: 18px;
@@ -110,7 +110,8 @@ import { DevToolbarFlag, FeatureFlagFilter } from './feature-flags.models';
           }
 
           ndt-select {
-            flex: 1;
+            flex: 0 0 auto;
+            min-width: 180px;
           }
         }
       }

--- a/libs/ngx-dev-toolbar/src/tools/home-tool/home-tool.component.scss
+++ b/libs/ngx-dev-toolbar/src/tools/home-tool/home-tool.component.scss
@@ -11,7 +11,7 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: var(--ndt-spacing-md);
+  gap: var(--ndt-spacing-sm);
 
   &__label {
     display: flex;
@@ -47,7 +47,7 @@
   .settings-actions {
     display: flex;
     gap: var(--ndt-spacing-md);
-    padding-block: var(--ndt-spacing-md);
+    padding-block: var(--ndt-spacing-sm);
 
     > * {
       width: 50%;

--- a/libs/ngx-dev-toolbar/src/tools/language-tool/language-internal.service.spec.ts
+++ b/libs/ngx-dev-toolbar/src/tools/language-tool/language-internal.service.spec.ts
@@ -1,0 +1,332 @@
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+import { DevToolsStorageService } from '../../utils/storage.service';
+import { DevToolbarInternalLanguageService } from './language-internal.service';
+import { Language } from './language.models';
+
+describe('DevToolbarInternalLanguageService', () => {
+  let service: DevToolbarInternalLanguageService;
+  let storageService: jest.Mocked<DevToolsStorageService>;
+
+  const createMockLanguage = (id: string, name: string): Language => ({
+    id,
+    name,
+  });
+
+  beforeEach(() => {
+    const storageServiceMock = {
+      get: jest.fn(),
+      set: jest.fn(),
+      remove: jest.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        DevToolbarInternalLanguageService,
+        { provide: DevToolsStorageService, useValue: storageServiceMock },
+      ],
+    });
+
+    service = TestBed.inject(DevToolbarInternalLanguageService);
+    storageService = TestBed.inject(
+      DevToolsStorageService
+    ) as jest.Mocked<DevToolsStorageService>;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('initialization', () => {
+    it('should initialize with empty languages', () => {
+      expect(service.languages()).toEqual([]);
+    });
+
+    it('should load forced language from localStorage on initialization', () => {
+      expect(storageService.get).toHaveBeenCalledWith('language');
+    });
+
+    it('should apply forced language from localStorage after setAppLanguages', () => {
+      const savedLanguage: Language = { id: 'en', name: 'English' };
+      storageService.get.mockReturnValue(savedLanguage);
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          DevToolbarInternalLanguageService,
+          { provide: DevToolsStorageService, useValue: storageService },
+        ],
+      });
+      const newService = TestBed.inject(DevToolbarInternalLanguageService);
+
+      const languages = [
+        createMockLanguage('en', 'English'),
+        createMockLanguage('es', 'Spanish'),
+      ];
+      newService.setAppLanguages(languages);
+
+      expect(storageService.get).toHaveBeenCalledWith('language');
+    });
+  });
+
+  describe('setAppLanguages', () => {
+    it('should update languages when setAppLanguages is called', () => {
+      const languages = [
+        createMockLanguage('en', 'English'),
+        createMockLanguage('es', 'Spanish'),
+        createMockLanguage('fr', 'French'),
+      ];
+
+      service.setAppLanguages(languages);
+
+      expect(service.languages()).toEqual(languages);
+    });
+
+    it('should handle empty languages array', () => {
+      service.setAppLanguages([]);
+
+      expect(service.languages()).toEqual([]);
+    });
+
+    it('should emit languages through getAppLanguages', async () => {
+      const languages = [
+        createMockLanguage('en', 'English'),
+        createMockLanguage('es', 'Spanish'),
+      ];
+
+      service.setAppLanguages(languages);
+
+      const result = await firstValueFrom(service.getAppLanguages());
+      expect(result).toEqual(languages);
+    });
+  });
+
+  describe('setForcedLanguage', () => {
+    it('should set forced language and persist to localStorage', () => {
+      const language = createMockLanguage('en', 'English');
+      service.setForcedLanguage(language);
+
+      expect(storageService.set).toHaveBeenCalledWith('language', language);
+    });
+
+    it('should emit forced language through getForcedLanguage', async () => {
+      const language = createMockLanguage('es', 'Spanish');
+      service.setForcedLanguage(language);
+
+      const result = await firstValueFrom(service.getForcedLanguage());
+      expect(result).toEqual([language]);
+    });
+
+    it('should replace previous forced language', async () => {
+      const firstLanguage = createMockLanguage('en', 'English');
+      const secondLanguage = createMockLanguage('es', 'Spanish');
+
+      service.setForcedLanguage(firstLanguage);
+      service.setForcedLanguage(secondLanguage);
+
+      const result = await firstValueFrom(service.getForcedLanguage());
+      expect(result).toEqual([secondLanguage]);
+    });
+  });
+
+  describe('removeForcedLanguage', () => {
+    it('should remove forced language and clear from localStorage', () => {
+      const language = createMockLanguage('en', 'English');
+      service.setForcedLanguage(language);
+
+      service.removeForcedLanguage();
+
+      expect(storageService.remove).toHaveBeenCalledWith('language');
+    });
+
+    it('should emit empty array through getForcedLanguage after removal', async () => {
+      const language = createMockLanguage('en', 'English');
+      service.setForcedLanguage(language);
+
+      service.removeForcedLanguage();
+
+      const result = await firstValueFrom(service.getForcedLanguage());
+      expect(result).toEqual([]);
+    });
+
+    it('should not throw error when removing non-existent forced language', () => {
+      expect(() => service.removeForcedLanguage()).not.toThrow();
+    });
+  });
+
+  describe('getForcedLanguage', () => {
+    it('should return empty array when no forced language set', async () => {
+      const result = await firstValueFrom(service.getForcedLanguage());
+      expect(result).toEqual([]);
+    });
+
+    it('should return array with single language when forced', async () => {
+      const language = createMockLanguage('fr', 'French');
+      service.setForcedLanguage(language);
+
+      const result = await firstValueFrom(service.getForcedLanguage());
+      expect(result).toEqual([language]);
+      expect(result.length).toBe(1);
+    });
+  });
+
+  describe('Preset Integration: applyPresetLanguage() and getCurrentForcedLanguage()', () => {
+    beforeEach(() => {
+      const languages = [
+        createMockLanguage('en', 'English'),
+        createMockLanguage('es', 'Spanish'),
+        createMockLanguage('fr', 'French'),
+      ];
+      service.setAppLanguages(languages);
+    });
+
+    it('should apply preset language by ID and set forced language', async () => {
+      await service.applyPresetLanguage('es');
+
+      const result = await firstValueFrom(service.getForcedLanguage());
+      expect(result.length).toBe(1);
+      expect(result[0].id).toBe('es');
+      expect(result[0].name).toBe('Spanish');
+    });
+
+    it('should persist applied preset language to localStorage', async () => {
+      await service.applyPresetLanguage('fr');
+
+      expect(storageService.set).toHaveBeenCalledWith('language', {
+        id: 'fr',
+        name: 'French',
+      });
+    });
+
+    it('should handle null languageId by removing forced language', async () => {
+      service.setForcedLanguage(createMockLanguage('en', 'English'));
+
+      await service.applyPresetLanguage(null);
+
+      const result = await firstValueFrom(service.getForcedLanguage());
+      expect(result).toEqual([]);
+      expect(storageService.remove).toHaveBeenCalledWith('language');
+    });
+
+    it('should log warning when language ID not found in available languages', async () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      await service.applyPresetLanguage('invalid-lang');
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Language invalid-lang not found')
+      );
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('should not apply forced language when ID not found', async () => {
+      service.setForcedLanguage(createMockLanguage('en', 'English'));
+
+      await service.applyPresetLanguage('invalid-lang');
+
+      // Should still have the old forced language since invalid ID was skipped
+      const result = await firstValueFrom(service.getForcedLanguage());
+      expect(result[0].id).toBe('en');
+    });
+
+    it('should handle empty available languages array gracefully', async () => {
+      service.setAppLanguages([]);
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      await service.applyPresetLanguage('en');
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Language en not found')
+      );
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('getCurrentForcedLanguage should return language ID when forced', () => {
+      service.setForcedLanguage(createMockLanguage('es', 'Spanish'));
+
+      const result = service.getCurrentForcedLanguage();
+      expect(result).toBe('es');
+    });
+
+    it('getCurrentForcedLanguage should return null when no forced language', () => {
+      const result = service.getCurrentForcedLanguage();
+      expect(result).toBe(null);
+    });
+
+    it('getCurrentForcedLanguage should return null after removing forced language', () => {
+      service.setForcedLanguage(createMockLanguage('en', 'English'));
+      service.removeForcedLanguage();
+
+      const result = service.getCurrentForcedLanguage();
+      expect(result).toBe(null);
+    });
+
+    it('applyPresetLanguage should work with async/await pattern', async () => {
+      await service.applyPresetLanguage('fr');
+
+      const currentId = service.getCurrentForcedLanguage();
+      expect(currentId).toBe('fr');
+    });
+
+    it('should handle rapid sequential preset applications', async () => {
+      await service.applyPresetLanguage('en');
+      await service.applyPresetLanguage('es');
+      await service.applyPresetLanguage('fr');
+
+      const result = await firstValueFrom(service.getForcedLanguage());
+      expect(result[0].id).toBe('fr');
+      expect(service.getCurrentForcedLanguage()).toBe('fr');
+    });
+  });
+
+  describe('localStorage persistence', () => {
+    it('should load forced language from localStorage on initialization', () => {
+      const savedLanguage: Language = { id: 'de', name: 'German' };
+      storageService.get.mockReturnValue(savedLanguage);
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          DevToolbarInternalLanguageService,
+          { provide: DevToolsStorageService, useValue: storageService },
+        ],
+      });
+      const newService = TestBed.inject(DevToolbarInternalLanguageService);
+
+      expect(storageService.get).toHaveBeenCalledWith('language');
+    });
+
+    it('should handle missing localStorage gracefully', () => {
+      storageService.get.mockReturnValue(null);
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          DevToolbarInternalLanguageService,
+          { provide: DevToolsStorageService, useValue: storageService },
+        ],
+      });
+
+      expect(() =>
+        TestBed.inject(DevToolbarInternalLanguageService)
+      ).not.toThrow();
+    });
+
+    it('should handle corrupted localStorage data gracefully', () => {
+      storageService.get.mockReturnValue({ invalid: 'data' } as any);
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          DevToolbarInternalLanguageService,
+          { provide: DevToolsStorageService, useValue: storageService },
+        ],
+      });
+      const newService = TestBed.inject(DevToolbarInternalLanguageService);
+
+      expect(newService.languages()).toEqual([]);
+    });
+  });
+});

--- a/libs/ngx-dev-toolbar/src/tools/language-tool/language-internal.service.ts
+++ b/libs/ngx-dev-toolbar/src/tools/language-tool/language-internal.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { BehaviorSubject, Observable, map } from 'rxjs';
+import { BehaviorSubject, Observable, firstValueFrom, map } from 'rxjs';
 import { DevToolsStorageService } from '../../utils/storage.service';
 import { Language } from './language.models';
 
@@ -47,5 +47,36 @@ export class DevToolbarInternalLanguageService {
     if (savedLanguage) {
       this.forcedLanguage$.next(savedLanguage);
     }
+  }
+
+  /**
+   * Apply language from a preset (used by Presets Tool)
+   * Accepts a language ID and finds the corresponding Language object from available languages
+   */
+  async applyPresetLanguage(languageId: string | null): Promise<void> {
+    if (languageId === null) {
+      this.removeForcedLanguage();
+      return;
+    }
+
+    // Get available languages and find matching one
+    const languages = await firstValueFrom(this.languages$);
+    const language = languages.find((lang) => lang.id === languageId);
+
+    if (language) {
+      this.setForcedLanguage(language);
+    } else {
+      console.warn(
+        `Language ${languageId} not found in available languages. Skipping.`
+      );
+    }
+  }
+
+  /**
+   * Get current forced language ID for saving to preset
+   * Returns the language ID or null if no language is forced
+   */
+  getCurrentForcedLanguage(): string | null {
+    return this.forcedLanguage$.value?.id ?? null;
   }
 }

--- a/libs/ngx-dev-toolbar/src/tools/permissions-tool/permissions-tool.component.ts
+++ b/libs/ngx-dev-toolbar/src/tools/permissions-tool/permissions-tool.component.ts
@@ -101,14 +101,14 @@ import {
         margin-bottom: var(--ndt-spacing-md);
 
         ndt-input {
-          flex: 0.65;
+          flex: 1;
         }
 
         .filter-wrapper {
-          flex: 0.35;
+          flex: 0 0 auto;
           display: flex;
           align-items: center;
-          gap: var(--ndt-spacing-xs);
+          gap: var(--ndt-spacing-md);
 
           .filter-icon {
             width: 18px;
@@ -118,7 +118,8 @@ import {
           }
 
           ndt-select {
-            flex: 1;
+            flex: 0 0 auto;
+            min-width: 180px;
           }
         }
       }

--- a/libs/ngx-dev-toolbar/src/tools/presets-tool/presets-internal.service.ts
+++ b/libs/ngx-dev-toolbar/src/tools/presets-tool/presets-internal.service.ts
@@ -1,0 +1,161 @@
+import { Injectable, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { DevToolsStorageService } from '../../utils/storage.service';
+import { DevToolbarInternalFeatureFlagService } from '../feature-flags-tool/feature-flags-internal.service';
+import { DevToolbarInternalLanguageService } from '../language-tool/language-internal.service';
+import { DevToolbarInternalPermissionsService } from '../permissions-tool/permissions-internal.service';
+import { DevToolbarInternalAppFeaturesService } from '../app-features-tool/app-features-internal.service';
+import { DevToolbarPreset, DevToolbarPresetConfig } from './presets.models';
+
+/**
+ * Internal service for managing presets state.
+ * Handles CRUD operations, captures current toolbar config, and applies presets.
+ */
+@Injectable({ providedIn: 'root' })
+export class DevToolbarInternalPresetsService {
+  private readonly STORAGE_KEY = 'presets';
+  private storageService = inject(DevToolsStorageService);
+
+  // Inject all other tool internal services (for reading/writing state)
+  private featureFlagsService = inject(DevToolbarInternalFeatureFlagService);
+  private languageService = inject(DevToolbarInternalLanguageService);
+  private permissionsService = inject(DevToolbarInternalPermissionsService);
+  private appFeaturesService = inject(DevToolbarInternalAppFeaturesService);
+
+  private presetsSubject = new BehaviorSubject<DevToolbarPreset[]>([]);
+  public presets$: Observable<DevToolbarPreset[]> =
+    this.presetsSubject.asObservable();
+  public presets = toSignal(this.presets$, { initialValue: [] });
+
+  constructor() {
+    this.loadPresets();
+  }
+
+  /**
+   * Capture current toolbar state as a new preset
+   */
+  saveCurrentAsPreset(
+    name: string,
+    description?: string
+  ): DevToolbarPreset {
+    const preset: DevToolbarPreset = {
+      id: this.generateId(),
+      name,
+      description,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      config: this.captureCurrentConfig(),
+    };
+
+    const presets = [...this.presetsSubject.value, preset];
+    this.presetsSubject.next(presets);
+    this.storageService.set(this.STORAGE_KEY, presets);
+
+    return preset;
+  }
+
+  /**
+   * Apply a preset to all tools (THIS IS THE KEY METHOD)
+   */
+  async applyPreset(presetId: string): Promise<void> {
+    const preset = this.presetsSubject.value.find((p) => p.id === presetId);
+    if (!preset) return;
+
+    // Apply to each tool's internal service
+    this.featureFlagsService.applyPresetFlags(preset.config.featureFlags);
+    await this.languageService.applyPresetLanguage(preset.config.language);
+    this.permissionsService.applyPresetPermissions(preset.config.permissions);
+    this.appFeaturesService.applyForcedState(preset.config.appFeatures);
+  }
+
+  /**
+   * Update an existing preset with current toolbar state
+   */
+  updatePreset(presetId: string): void {
+    const presets = this.presetsSubject.value.map((preset) => {
+      if (preset.id === presetId) {
+        return {
+          ...preset,
+          updatedAt: new Date().toISOString(),
+          config: this.captureCurrentConfig(),
+        };
+      }
+      return preset;
+    });
+
+    this.presetsSubject.next(presets);
+    this.storageService.set(this.STORAGE_KEY, presets);
+  }
+
+  /**
+   * Delete a preset
+   */
+  deletePreset(presetId: string): void {
+    const presets = this.presetsSubject.value.filter(
+      (p) => p.id !== presetId
+    );
+    this.presetsSubject.next(presets);
+    this.storageService.set(this.STORAGE_KEY, presets);
+  }
+
+  /**
+   * Add a preset (used for import)
+   */
+  addPreset(preset: DevToolbarPreset): DevToolbarPreset {
+    // Generate new ID to avoid conflicts
+    const newPreset: DevToolbarPreset = {
+      ...preset,
+      id: this.generateId(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const presets = [...this.presetsSubject.value, newPreset];
+    this.presetsSubject.next(presets);
+    this.storageService.set(this.STORAGE_KEY, presets);
+
+    return newPreset;
+  }
+
+  /**
+   * Get a preset by ID
+   */
+  getPresetById(presetId: string): DevToolbarPreset | undefined {
+    return this.presetsSubject.value.find((p) => p.id === presetId);
+  }
+
+  /**
+   * Capture current configuration from all tools
+   */
+  private captureCurrentConfig(): DevToolbarPresetConfig {
+    return {
+      featureFlags: this.featureFlagsService.getCurrentForcedState(),
+      language: this.languageService.getCurrentForcedLanguage(),
+      permissions: this.permissionsService.getCurrentForcedState(),
+      appFeatures: this.appFeaturesService.getCurrentForcedState(),
+    };
+  }
+
+  /**
+   * Load presets from localStorage
+   */
+  private loadPresets(): void {
+    try {
+      const saved =
+        this.storageService.get<DevToolbarPreset[]>(this.STORAGE_KEY);
+      if (saved && Array.isArray(saved)) {
+        this.presetsSubject.next(saved);
+      }
+    } catch (error) {
+      console.error('Failed to load presets from localStorage:', error);
+    }
+  }
+
+  /**
+   * Generate unique preset ID
+   */
+  private generateId(): string {
+    return `preset-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+  }
+}

--- a/libs/ngx-dev-toolbar/src/tools/presets-tool/presets-tool.component.ts
+++ b/libs/ngx-dev-toolbar/src/tools/presets-tool/presets-tool.component.ts
@@ -1,0 +1,528 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DevToolbarButtonComponent } from '../../components/button/button.component';
+import { DevToolbarIconComponent } from '../../components/icons/icon.component';
+import { DevToolbarInputComponent } from '../../components/input/input.component';
+import { DevToolbarToolComponent } from '../../components/toolbar-tool/toolbar-tool.component';
+import { DevToolbarWindowOptions } from '../../components/toolbar-tool/toolbar-tool.models';
+import { DevToolbarWindowComponent } from '../../components/window/window.component';
+import { DevToolbarInternalPresetsService } from './presets-internal.service';
+import { DevToolbarInternalFeatureFlagService } from '../feature-flags-tool/feature-flags-internal.service';
+import { DevToolbarInternalPermissionsService } from '../permissions-tool/permissions-internal.service';
+import { DevToolbarInternalAppFeaturesService } from '../app-features-tool/app-features-internal.service';
+import { DevToolbarInternalLanguageService } from '../language-tool/language-internal.service';
+
+@Component({
+  selector: 'ndt-presets-tool',
+  standalone: true,
+  imports: [
+    FormsModule,
+    DevToolbarToolComponent,
+    DevToolbarInputComponent,
+    DevToolbarButtonComponent,
+    DevToolbarIconComponent,
+    DevToolbarWindowComponent,
+  ],
+  template: `
+    <ndt-toolbar-tool [options]="options" title="Presets" icon="layout">
+      <div class="container">
+        <!-- Mode Toggle -->
+        @if (!hasNoPresets() || viewMode() === 'create') {
+        <div class="header">
+          @if (viewMode() === 'list') {
+          <ndt-input
+            [value]="searchQuery()"
+            (valueChange)="onSearchChange($event)"
+            placeholder="Search presets..."
+            [ariaLabel]="'Search presets'"
+          />
+          <ndt-button
+            (click)="onSwitchToCreateMode()"
+            [ariaLabel]="'Create new preset'"
+          >
+            New Preset
+          </ndt-button>
+          } @else {
+          <ndt-button
+            (click)="onSwitchToListMode()"
+            [ariaLabel]="'Back to list'"
+          >
+            ← Back to List
+          </ndt-button>
+          }
+        </div>
+        }
+
+        <!-- Create Form -->
+        @if (viewMode() === 'create') {
+        <form (submit)="onSavePreset($event)" class="preset-form">
+          <ndt-input
+            label="Preset Name"
+            [value]="presetName()"
+            (valueChange)="presetName.set($event)"
+            placeholder="e.g., Admin User - Full Access"
+            [ariaLabel]="'Preset name'"
+          />
+          <ndt-input
+            label="Description (optional)"
+            [value]="presetDescription()"
+            (valueChange)="presetDescription.set($event)"
+            placeholder="Brief description of this preset"
+            [ariaLabel]="'Preset description'"
+          />
+
+          <!-- Summary of what will be saved -->
+          <div class="preset-summary">
+            <h4>Configuration to Save:</h4>
+            <ul>
+              <li>Feature Flags: {{ getCurrentFlagsCount() }} forced</li>
+              <li>Permissions: {{ getCurrentPermissionsCount() }} forced</li>
+              <li>App Features: {{ getCurrentAppFeaturesCount() }} forced</li>
+              <li>Language: {{ getCurrentLanguage() }}</li>
+            </ul>
+          </div>
+
+          <div class="form-actions">
+            <ndt-button type="submit">Save Preset</ndt-button>
+          </div>
+        </form>
+        }
+
+        <!-- Empty State -->
+        @if (viewMode() === 'list' && hasNoPresets()) {
+        <div class="empty">
+          <p>No presets saved yet</p>
+          <p class="hint">
+            Save the current toolbar configuration as a preset for quick access
+          </p>
+          <ndt-button (click)="onSwitchToCreateMode()">
+            Create Your First Preset
+          </ndt-button>
+        </div>
+        } @else if (viewMode() === 'list' && hasNoFilteredPresets()) {
+        <div class="empty">
+          <p>No presets match your search</p>
+        </div>
+        } @else if (viewMode() === 'list') {
+        <!-- Preset List -->
+        <div class="preset-list">
+          @for (preset of filteredPresets(); track preset.id) {
+          <div class="preset-card">
+            <div class="preset-card__header">
+              <h3>{{ preset.name }}</h3>
+              <div class="preset-card__actions">
+                <button
+                  class="icon-button"
+                  (click)="onApplyPreset(preset.id)"
+                  [attr.aria-label]="'Apply preset ' + preset.name"
+                  title="Apply preset"
+                >
+                  <ndt-icon name="refresh" />
+                </button>
+                <button
+                  class="icon-button"
+                  (click)="onUpdatePreset(preset.id)"
+                  [attr.aria-label]="'Update preset ' + preset.name"
+                  title="Update with current state"
+                >
+                  <ndt-icon name="gear" />
+                </button>
+                <button
+                  class="icon-button"
+                  (click)="onExportPreset(preset.id)"
+                  [attr.aria-label]="'Export preset ' + preset.name"
+                  title="Export as JSON"
+                >
+                  <ndt-icon name="export" />
+                </button>
+                <button
+                  class="icon-button"
+                  (click)="onDeletePreset(preset.id)"
+                  [attr.aria-label]="'Delete preset ' + preset.name"
+                  title="Delete preset"
+                >
+                  <ndt-icon name="trash" />
+                </button>
+              </div>
+            </div>
+            @if (preset.description) {
+            <p class="preset-card__description">{{ preset.description }}</p>
+            }
+            <div class="preset-card__meta">
+              <span>Updated: {{ formatDate(preset.updatedAt) }}</span>
+            </div>
+            <!-- Preview of preset config -->
+            <div class="preset-card__preview">
+              @if (preset.config.featureFlags.enabled.length > 0 ||
+              preset.config.featureFlags.disabled.length > 0) {
+              <span class="badge">
+                {{
+                  preset.config.featureFlags.enabled.length +
+                    preset.config.featureFlags.disabled.length
+                }}
+                flags
+              </span>
+              } @if (preset.config.permissions.granted.length > 0 ||
+              preset.config.permissions.denied.length > 0) {
+              <span class="badge">
+                {{
+                  preset.config.permissions.granted.length +
+                    preset.config.permissions.denied.length
+                }}
+                perms
+              </span>
+              } @if (preset.config.appFeatures.enabled.length > 0 ||
+              preset.config.appFeatures.disabled.length > 0) {
+              <span class="badge">
+                {{
+                  preset.config.appFeatures.enabled.length +
+                    preset.config.appFeatures.disabled.length
+                }}
+                features
+              </span>
+              } @if (preset.config.language) {
+              <span class="badge">{{ preset.config.language }}</span>
+              }
+            </div>
+          </div>
+          }
+        </div>
+        }
+      </div>
+    </ndt-toolbar-tool>
+  `,
+  styles: [
+    `
+      .container {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+      }
+
+      .header {
+        flex-shrink: 0;
+        display: flex;
+        gap: var(--ndt-spacing-sm);
+        margin-bottom: var(--ndt-spacing-md);
+
+        ndt-input {
+          flex: 1;
+        }
+
+        ndt-button {
+          flex-shrink: 0;
+        }
+      }
+
+      .empty {
+        display: flex;
+        flex-direction: column;
+        gap: var(--ndt-spacing-md);
+        flex: 1;
+        min-height: 0;
+        justify-content: center;
+        align-items: center;
+        border: 1px solid var(--ndt-border-subtle);
+        border-radius: var(--ndt-border-radius-medium);
+        padding: var(--ndt-spacing-md);
+        background: transparent;
+        color: var(--ndt-text-muted);
+        text-align: center;
+
+        p {
+          margin: 0;
+        }
+
+        .hint {
+          font-size: var(--ndt-font-size-xs);
+        }
+      }
+
+      .preset-list {
+        display: flex;
+        flex-direction: column;
+        gap: var(--ndt-spacing-md);
+        flex: 1;
+        min-height: 0;
+        overflow-y: auto;
+        padding-right: var(--ndt-spacing-sm);
+
+        &::-webkit-scrollbar {
+          width: 8px;
+        }
+
+        &::-webkit-scrollbar-track {
+          background: var(--ndt-background-secondary);
+          border-radius: 4px;
+        }
+
+        &::-webkit-scrollbar-thumb {
+          background: var(--ndt-border-primary);
+          border-radius: 4px;
+
+          &:hover {
+            background: var(--ndt-hover-bg);
+          }
+        }
+
+        scrollbar-width: thin;
+        scrollbar-color: var(--ndt-border-primary)
+          var(--ndt-background-secondary);
+      }
+
+      .preset-card {
+        background: var(--ndt-background-secondary);
+        padding: var(--ndt-spacing-md);
+        border-radius: var(--ndt-border-radius-medium);
+        display: flex;
+        flex-direction: column;
+        gap: var(--ndt-spacing-sm);
+      }
+
+      .preset-card__header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: var(--ndt-spacing-sm);
+
+        h3 {
+          margin: 0;
+          font-size: var(--ndt-font-size-md);
+          color: var(--ndt-text-primary);
+          flex: 1;
+        }
+      }
+
+      .preset-card__actions {
+        display: flex;
+        gap: var(--ndt-spacing-xs);
+      }
+
+      .icon-button {
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        padding: var(--ndt-spacing-xs);
+        border-radius: var(--ndt-border-radius-small);
+        color: var(--ndt-text-secondary);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        &:hover {
+          background: var(--ndt-hover-bg);
+          color: var(--ndt-text-primary);
+        }
+
+        ndt-icon {
+          width: 16px;
+          height: 16px;
+        }
+      }
+
+      .preset-card__description {
+        margin: 0;
+        font-size: var(--ndt-font-size-sm);
+        color: var(--ndt-text-secondary);
+      }
+
+      .preset-card__meta {
+        font-size: var(--ndt-font-size-xs);
+        color: var(--ndt-text-muted);
+
+        span {
+          margin-right: var(--ndt-spacing-sm);
+        }
+      }
+
+      .preset-card__preview {
+        display: flex;
+        gap: var(--ndt-spacing-xs);
+        flex-wrap: wrap;
+      }
+
+      .badge {
+        background: var(--ndt-primary-color);
+        color: white;
+        padding: 2px 8px;
+        border-radius: 12px;
+        font-size: var(--ndt-font-size-xs);
+        font-weight: 500;
+      }
+
+      .preset-form {
+        flex: 1;
+        min-height: 0;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+        gap: var(--ndt-spacing-md);
+        padding: var(--ndt-spacing-md);
+
+        ndt-input {
+          width: 100%;
+        }
+      }
+
+      .preset-summary {
+        background: var(--ndt-background-secondary);
+        padding: var(--ndt-spacing-md);
+        border-radius: var(--ndt-border-radius-medium);
+
+        h4 {
+          margin: 0 0 var(--ndt-spacing-sm) 0;
+          font-size: var(--ndt-font-size-sm);
+          color: var(--ndt-text-primary);
+        }
+
+        ul {
+          margin: 0;
+          padding-left: var(--ndt-spacing-md);
+          color: var(--ndt-text-secondary);
+          font-size: var(--ndt-font-size-sm);
+
+          li {
+            margin-bottom: var(--ndt-spacing-xs);
+          }
+        }
+      }
+
+      .form-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: var(--ndt-spacing-sm);
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DevToolbarPresetsToolComponent {
+  // Injects
+  private readonly presetsService = inject(DevToolbarInternalPresetsService);
+  private readonly featureFlagsService = inject(
+    DevToolbarInternalFeatureFlagService
+  );
+  private readonly permissionsService = inject(
+    DevToolbarInternalPermissionsService
+  );
+  private readonly appFeaturesService = inject(
+    DevToolbarInternalAppFeaturesService
+  );
+  private readonly languageService = inject(DevToolbarInternalLanguageService);
+
+  // Signals
+  protected readonly viewMode = signal<'list' | 'create'>('list');
+  protected readonly searchQuery = signal<string>('');
+  protected readonly presetName = signal<string>('');
+  protected readonly presetDescription = signal<string>('');
+
+  protected readonly presets = this.presetsService.presets;
+  protected readonly filteredPresets = computed(() => {
+    const query = this.searchQuery().toLowerCase();
+    return this.presets().filter(
+      (preset) =>
+        preset.name.toLowerCase().includes(query) ||
+        preset.description?.toLowerCase().includes(query)
+    );
+  });
+
+  protected readonly hasNoPresets = computed(
+    () => this.presets().length === 0
+  );
+  protected readonly hasNoFilteredPresets = computed(
+    () => this.filteredPresets().length === 0
+  );
+
+  // Other properties
+  protected readonly options: DevToolbarWindowOptions = {
+    title: 'Presets',
+    description: 'Save and load toolbar configurations',
+    isClosable: true,
+    size: 'tall',
+    id: 'ndt-presets',
+    isBeta: true,
+  };
+
+  // Public methods
+  onSearchChange(query: string): void {
+    this.searchQuery.set(query);
+  }
+
+  onSwitchToCreateMode(): void {
+    this.viewMode.set('create');
+    this.presetName.set('');
+    this.presetDescription.set('');
+  }
+
+  onSwitchToListMode(): void {
+    this.viewMode.set('list');
+  }
+
+  onSavePreset(event: Event): void {
+    event.preventDefault();
+    if (!this.presetName()) return;
+    this.presetsService.saveCurrentAsPreset(
+      this.presetName(),
+      this.presetDescription()
+    );
+    this.onSwitchToListMode();
+  }
+
+  onApplyPreset(presetId: string): void {
+    this.presetsService.applyPreset(presetId);
+  }
+
+  onUpdatePreset(presetId: string): void {
+    this.presetsService.updatePreset(presetId);
+  }
+
+  onExportPreset(presetId: string): void {
+    const preset = this.presets().find((p) => p.id === presetId);
+    if (!preset) return;
+
+    const json = JSON.stringify(preset, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `preset-${preset.name.toLowerCase().replace(/\s+/g, '-')}.json`;
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
+  onDeletePreset(presetId: string): void {
+    if (confirm('Are you sure you want to delete this preset?')) {
+      this.presetsService.deletePreset(presetId);
+    }
+  }
+
+  // Protected methods
+  protected getCurrentFlagsCount(): number {
+    const state = this.featureFlagsService.getCurrentForcedState();
+    return state.enabled.length + state.disabled.length;
+  }
+
+  protected getCurrentPermissionsCount(): number {
+    const state = this.permissionsService.getCurrentForcedState();
+    return state.granted.length + state.denied.length;
+  }
+
+  protected getCurrentAppFeaturesCount(): number {
+    const state = this.appFeaturesService.getCurrentForcedState();
+    return state.enabled.length + state.disabled.length;
+  }
+
+  protected getCurrentLanguage(): string {
+    return this.languageService.getCurrentForcedLanguage() || 'Not Forced';
+  }
+
+  protected formatDate(isoString: string): string {
+    return new Date(isoString).toLocaleDateString();
+  }
+}

--- a/libs/ngx-dev-toolbar/src/tools/presets-tool/presets.models.ts
+++ b/libs/ngx-dev-toolbar/src/tools/presets-tool/presets.models.ts
@@ -1,0 +1,26 @@
+export interface DevToolbarPreset {
+  id: string;
+  name: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+  config: DevToolbarPresetConfig;
+}
+
+export interface DevToolbarPresetConfig {
+  featureFlags: {
+    enabled: string[];
+    disabled: string[];
+  };
+  language: string | null;
+  permissions: {
+    granted: string[];
+    denied: string[];
+  };
+  appFeatures: {
+    enabled: string[];
+    disabled: string[];
+  };
+}
+
+export type PresetFilter = 'all' | 'recent' | 'favorites';

--- a/libs/ngx-dev-toolbar/src/tools/presets-tool/presets.service.ts
+++ b/libs/ngx-dev-toolbar/src/tools/presets-tool/presets.service.ts
@@ -1,0 +1,76 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { DevToolbarInternalPresetsService } from './presets-internal.service';
+import { DevToolbarPreset } from './presets.models';
+
+/**
+ * Public service for managing dev toolbar presets.
+ * Allows developers to programmatically save, load, and manage presets.
+ */
+@Injectable({ providedIn: 'root' })
+export class DevToolbarPresetsService {
+  private internalService = inject(DevToolbarInternalPresetsService);
+
+  /**
+   * Get all saved presets as an Observable
+   */
+  getPresets(): Observable<DevToolbarPreset[]> {
+    return this.internalService.presets$;
+  }
+
+  /**
+   * Save current toolbar state as a preset
+   * @param name - Name for the preset
+   * @param description - Optional description
+   * @returns The created preset
+   */
+  savePreset(name: string, description?: string): DevToolbarPreset {
+    return this.internalService.saveCurrentAsPreset(name, description);
+  }
+
+  /**
+   * Apply a preset (load its configuration into all tools)
+   * @param presetId - ID of the preset to apply
+   */
+  async applyPreset(presetId: string): Promise<void> {
+    return this.internalService.applyPreset(presetId);
+  }
+
+  /**
+   * Update a preset with current toolbar state
+   * @param presetId - ID of the preset to update
+   */
+  updatePreset(presetId: string): void {
+    this.internalService.updatePreset(presetId);
+  }
+
+  /**
+   * Delete a preset
+   * @param presetId - ID of the preset to delete
+   */
+  deletePreset(presetId: string): void {
+    this.internalService.deletePreset(presetId);
+  }
+
+  /**
+   * Export a preset as JSON string
+   * @param presetId - ID of the preset to export
+   * @returns JSON string representation of the preset
+   */
+  exportPreset(presetId: string): string | null {
+    const preset = this.internalService.getPresetById(presetId);
+    if (!preset) return null;
+    return JSON.stringify(preset, null, 2);
+  }
+
+  /**
+   * Import a preset from JSON string
+   * @param json - JSON string representation of a preset
+   * @returns The imported preset
+   * @throws Error if JSON is invalid
+   */
+  importPreset(json: string): DevToolbarPreset {
+    const preset = JSON.parse(json) as DevToolbarPreset;
+    return this.internalService.addPreset(preset);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,10 @@
         "@angular/router": "~19.0.0",
         "@angular/ssr": "~19.0.0",
         "@jsverse/transloco": "^7.5.1",
+        "@types/prismjs": "^1.26.5",
         "express": "~4.18.2",
         "ngx-highlightjs": "^13.0.0",
+        "prismjs": "^1.30.0",
         "rxjs": "~7.8.0",
         "zone.js": "~0.15.0"
       },
@@ -8226,15 +8228,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@polka/url": {
-      "version": "1.0.0-next.28",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
-      "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@release-it/bumper": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@release-it/bumper/-/bumper-6.0.1.tgz",
@@ -9660,6 +9653,12 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "dev": true
     },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.5",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
+      "integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/qs": {
       "version": "6.9.17",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.17.tgz",
@@ -10047,30 +10046,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/ui": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-1.6.0.tgz",
-      "integrity": "sha512-k3Lyo+ONLOgylctiGovRKy7V4+dIN2yxstX3eY5cWFXH6WP+ooVX79YSyi0GagdTQzLmT43BF27T0s6dOIPBXA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vitest/utils": "1.6.0",
-        "fast-glob": "^3.3.2",
-        "fflate": "^0.8.1",
-        "flatted": "^3.2.9",
-        "pathe": "^1.1.1",
-        "picocolors": "^1.0.0",
-        "sirv": "^2.0.4"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "vitest": "1.6.0"
       }
     },
     "node_modules/@vitest/utils": {
@@ -14447,15 +14422,6 @@
         }
       }
     },
-    "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -15141,34 +15107,6 @@
         "conventional-commits-parser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/conventional-commits-filter": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
-      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/conventional-commits-parser": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.0.0.tgz",
-      "integrity": "sha512-TbsINLp48XeMXR8EvGjTnKGsZqBemisPoyWESlpRyR8lif0lcwzqz+NMtYSj1ooF/WYjSuu7wX0CtdeeMEQAmA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/git-semver-tags/node_modules/meow": {
@@ -21866,6 +21804,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/proc-log": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
@@ -23937,23 +23884,6 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/sirv": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
-      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@polka/url": "^1.0.0-next.24",
-        "mrmime": "^2.0.0",
-        "totalist": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -25153,18 +25083,6 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/totalist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
-      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
     "@angular/router": "~19.0.0",
     "@angular/ssr": "~19.0.0",
     "@jsverse/transloco": "^7.5.1",
+    "@types/prismjs": "^1.26.5",
     "express": "~4.18.2",
     "ngx-highlightjs": "^13.0.0",
+    "prismjs": "^1.30.0",
     "rxjs": "~7.8.0",
     "zone.js": "~0.15.0"
   },

--- a/specs/003-add-comprehensive-documentation/checklists/requirements.md
+++ b/specs/003-add-comprehensive-documentation/checklists/requirements.md
@@ -1,0 +1,75 @@
+# Specification Quality Checklist: Comprehensive Documentation Website
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-10-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Validation Results
+
+### ✅ Content Quality - PASSED
+
+- Specification focuses on what developers need (documentation, examples, navigation) without specifying implementation technologies
+- Written in clear language accessible to product owners and stakeholders
+- All mandatory sections (User Scenarios, Requirements, Success Criteria, Scope) are complete
+
+### ✅ Requirement Completeness - PASSED
+
+- All 29 functional requirements are specific and testable (e.g., "Each tool page MUST display syntax-highlighted code examples")
+- Success criteria include measurable metrics (e.g., "within 30 seconds", "2 clicks", "under 2 seconds", "90% task completion rate")
+- Success criteria avoid implementation details - focused on user outcomes
+- All user stories have clear acceptance scenarios in Given-When-Then format
+- Edge cases identified (404 handling, layout with long code, mobile responsiveness, etc.)
+- Clear scope boundaries defined (in-scope: 5 tool docs, out-of-scope: version switching, multi-language, interactive playground)
+- Dependencies listed (existing docs app, SEO service, routing) and assumptions documented (Angular 19+ syntax, developer audience)
+
+### ✅ Feature Readiness - PASSED
+
+- Each functional requirement maps to acceptance scenarios in user stories
+- User scenarios prioritized (P1: Landing + Tool Docs, P2: Navigation, P3: Search) and independently testable
+- Success criteria provide clear measurable outcomes (time, clicks, completion rates)
+- No framework-specific or implementation details present in requirements or success criteria
+
+## Notes
+
+**Status**: ✅ Specification is complete and ready for planning phase
+
+All checklist items pass validation. The specification:
+- Clearly defines what needs to be built (5 tool documentation pages, navigation, code examples)
+- Provides measurable success criteria focused on user outcomes
+- Maintains technology-agnostic language throughout
+- Includes 24 comprehensive functional requirements covering all aspects (content, navigation, examples, responsiveness)
+- Properly scopes the feature with clear boundaries (landing page and search explicitly out of scope)
+- Has no ambiguous or unclear requirements requiring clarification
+
+**Updates**:
+- Removed landing page work (user confirmed existing landing page is satisfactory)
+- Removed search functionality (out of scope for now)
+- Reduced from 4 user stories to 2 focused user stories (P1: Tool Documentation, P2: Navigation)
+- Requirements renumbered from FR-001 to FR-024 for clarity
+
+**Recommendation**: Proceed to `/speckit.plan` phase to create implementation planning document.

--- a/specs/003-add-comprehensive-documentation/spec.md
+++ b/specs/003-add-comprehensive-documentation/spec.md
@@ -1,0 +1,192 @@
+# Feature Specification: Comprehensive Documentation Website
+
+**Feature Branch**: `003-add-comprehensive-documentation`
+**Created**: 2025-10-12
+**Status**: Draft
+**Input**: User description: "Add comprehensive documentation to docs website with landing page and detailed tool guides with examples"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Developer Learns About Specific Tools (Priority: P1)
+
+A developer wants to understand how to use specific tools (Feature Flags, Language Switcher, Permissions, App Features, Presets) in their application. They need clear explanations, API references, and working code examples.
+
+**Why this priority**: Detailed tool documentation is essential for successful implementation. Without clear guides and examples, developers cannot effectively use the library.
+
+**Independent Test**: Can be tested by navigating to any tool's documentation page and verifying it contains a complete explanation, API reference, usage examples, and integration instructions. Delivers value by enabling developers to successfully implement any single tool.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer navigates to a tool's documentation page, **When** the page loads, **Then** they see a comprehensive guide including: purpose, use cases, API reference, and code examples
+2. **Given** a developer is reading tool documentation, **When** they view code examples, **Then** they see syntax-highlighted, copy-able code snippets with explanations
+3. **Given** a developer needs API details, **When** they scroll to the API section, **Then** they see method signatures, parameter descriptions, return types, and usage notes
+4. **Given** a developer wants to see the tool in action, **When** they view examples, **Then** they see both basic and advanced implementation patterns
+5. **Given** a developer finishes reading about one tool, **When** they look for navigation, **Then** they see links to other tool documentation and can easily switch between tools
+
+---
+
+### User Story 2 - Developer Navigates Documentation (Priority: P2)
+
+A developer using the documentation needs to easily find specific information, navigate between different sections, and understand the overall structure of the library's capabilities.
+
+**Why this priority**: Good navigation improves user experience and reduces time-to-value. However, it's secondary to having the actual content available.
+
+**Independent Test**: Can be tested by verifying the navigation menu works correctly, displays all sections, highlights the current page, and allows quick jumping between documentation sections. Delivers value by making the existing documentation more accessible.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer is on any documentation page, **When** they view the page, **Then** they see a persistent navigation menu showing all documentation sections
+2. **Given** a developer is on a specific tool's page, **When** they look at the navigation, **Then** the current page is highlighted/indicated
+3. **Given** a developer clicks a navigation link, **When** the new page loads, **Then** the navigation persists and updates to show the new current page
+4. **Given** a developer is on mobile, **When** they access the documentation, **Then** they see a responsive menu that adapts to smaller screens
+
+---
+
+### Edge Cases
+
+- What happens when a developer accesses documentation for a tool that doesn't exist (404 page)?
+- How does the site handle very long code examples that might break layout?
+- What happens when JavaScript is disabled (progressive enhancement)?
+- How does the documentation handle different screen sizes and devices?
+- What happens when a developer tries to copy code examples with special characters?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Tool Documentation Pages
+
+- **FR-001**: Each tool MUST have a dedicated documentation page accessible via routing
+- **FR-002**: Each tool page MUST include: purpose statement, use cases, API reference, and code examples
+- **FR-003**: Each tool page MUST display syntax-highlighted code examples
+- **FR-004**: Each tool page MUST provide copy-to-clipboard functionality for code snippets
+- **FR-005**: Each tool page MUST document the public service API including method signatures, parameters, and return types
+- **FR-006**: Each tool page MUST show at least one basic usage example and one advanced usage example
+
+#### Tool Coverage
+
+- **FR-007**: Documentation MUST cover the Feature Flags Tool with complete API and examples
+- **FR-008**: Documentation MUST cover the Language Tool with complete API and examples
+- **FR-009**: Documentation MUST cover the Permissions Tool with complete API and examples
+- **FR-010**: Documentation MUST cover the App Features Tool with complete API and examples
+- **FR-011**: Documentation MUST cover the Presets Tool with complete API and examples
+
+#### Navigation & Structure
+
+- **FR-012**: Site MUST provide a navigation menu showing all documentation sections
+- **FR-013**: Navigation MUST indicate the current page/section
+- **FR-014**: Navigation MUST persist across all pages
+- **FR-015**: Site MUST use routing to enable deep-linking to specific documentation pages
+- **FR-016**: Site MUST be responsive and usable on mobile, tablet, and desktop devices
+
+#### Code Examples
+
+- **FR-017**: Code examples MUST be syntactically correct and runnable
+- **FR-018**: Code examples MUST include inline comments explaining key concepts
+- **FR-019**: Code examples MUST demonstrate integration with Angular applications (components, services, etc.)
+- **FR-020**: Code examples MUST show both TypeScript and template code where applicable
+
+#### Content Quality
+
+- **FR-021**: All documentation MUST be written in clear, professional English
+- **FR-022**: Technical terms MUST be explained on first use
+- **FR-023**: Each tool's purpose MUST be explained in non-technical terms before diving into implementation details
+- **FR-024**: Documentation MUST include visual aids (diagrams, screenshots) where helpful for understanding
+
+### Key Entities *(include if feature involves data)*
+
+- **Documentation Page**: Represents a single documentation page with title, content, route path, and navigation metadata
+- **Tool Documentation**: Represents complete documentation for a specific tool including API reference, examples, use cases
+- **Code Example**: Represents a code snippet with syntax highlighting metadata, language, and copyable content
+- **Navigation Item**: Represents a menu item with label, route path, active state, and optional child items
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Developers can find installation instructions within 30 seconds of landing on the site
+- **SC-002**: Each tool's documentation page can be accessed within 2 clicks from the landing page
+- **SC-003**: Documentation site loads initial content in under 2 seconds on standard broadband connections
+- **SC-004**: Code examples can be copied with a single click
+- **SC-005**: All tool documentation pages include at least one complete, runnable code example
+- **SC-006**: Navigation menu is accessible and usable on screens as small as 320px width
+- **SC-007**: Documentation covers 100% of the public API for all five tools
+- **SC-008**: Each tool's purpose can be understood by reading the first paragraph of its documentation
+- **SC-009**: Search engines can index all documentation pages (proper meta tags and structure)
+- **SC-010**: Developers report a task completion rate of 90% or higher for common tasks (installing library, implementing a tool)
+
+## Scope & Boundaries *(mandatory)*
+
+### In Scope
+
+- Individual documentation pages for all 5 tools (Feature Flags, Language, Permissions, App Features, Presets)
+- Navigation system for documentation sections
+- Code syntax highlighting
+- Copy-to-clipboard functionality for code examples
+- Responsive design for mobile/tablet/desktop
+- SEO optimization (meta tags, structured data) for documentation pages
+- Routing for deep-linking to specific tool documentation
+
+### Out of Scope
+
+- Landing page modifications (already complete and satisfactory)
+- Documentation search functionality
+- Interactive playground/sandbox for trying tools
+- User authentication or personalized documentation
+- Version switching for documentation (only current version)
+- Multi-language documentation (English only for now)
+- Video tutorials or animated guides
+- Community-contributed documentation
+- API changelog or version history
+- Comment system or user feedback widgets
+
+## Dependencies & Assumptions *(mandatory)*
+
+### Dependencies
+
+- Existing Angular application structure in `apps/documentation`
+- Current landing page components and structure
+- SEO service and analytics service already in place
+- Routing infrastructure (Angular Router)
+
+### Assumptions
+
+- Documentation will be maintained in the same repository as the library code
+- Documentation is targeting Angular developers familiar with TypeScript and RxJS
+- All tools are stable and their APIs will not change during documentation creation
+- Code examples will use Angular 19+ syntax (standalone components, signals)
+- Developers have basic understanding of Angular concepts (components, services, dependency injection)
+- Documentation site is static-generated for performance and hosting simplicity
+- Tool icons and visual assets are already available in the project
+
+## Non-Functional Requirements *(optional - only if relevant)*
+
+### Performance
+
+- Initial page load < 2 seconds on 3G connections
+- Navigation between pages < 500ms
+- Code syntax highlighting < 100ms per code block
+
+### Accessibility
+
+- WCAG 2.1 AA compliant
+- Keyboard navigation for all interactive elements
+- Screen reader compatible
+- Sufficient color contrast for readability
+
+### SEO
+
+- Proper semantic HTML structure
+- Meta tags for social sharing (Open Graph, Twitter Cards)
+- Structured data for search engines
+- Descriptive URLs for each documentation page
+
+### Browser Support
+
+- Modern browsers (Chrome, Firefox, Safari, Edge) - last 2 versions
+- Mobile browsers (iOS Safari, Chrome Android)
+- Graceful degradation for older browsers
+
+## Open Questions *(optional - only if questions remain)*
+
+None - all requirements are clear based on the existing documentation app structure and the user's request.


### PR DESCRIPTION
 - Implemented complete documentation website with dedicated pages for all five toolbar tools (Feature Flags, Language, Permissions, App Features, Presets)
 - Added Presets Tool to library for saving/loading complete toolbar configurations   including feature flags, permissions, language settings, and app features
 - Created shared documentation components: code example viewer with Prism.js, API reference with collapsible sections, and responsive navigation sidebar
 - Updated README with Presets Tool listing and corrected Angular version badge to 19+