### PR TITLE
feat(toolbar): add custom tools API and tabs component

### DIFF
--- a/apps/ngx-dev-toolbar-demo/src/app/app.config.ts
+++ b/apps/ngx-dev-toolbar-demo/src/app/app.config.ts
@@ -5,6 +5,7 @@ import { provideTransloco } from '@jsverse/transloco';
 import { provideTranslateService } from '@ngx-translate/core';
 import { provideTranslateHttpLoader } from '@ngx-translate/http-loader';
 import { provideToolbar } from 'ngx-dev-toolbar';
+import { ToolbarCustomToolComponent } from './components/custom-tool/custom-tool.component';
 import { appRoutes } from './app.routes';
 import { TranslocoHttpLoader } from './services/transloco-http-loader';
 
@@ -35,6 +36,7 @@ export const appConfig: ApplicationConfig = {
       showAppFeaturesTool: true,
       showPermissionsTool: true,
       showPresetsTool: true,
+      customTools: [ToolbarCustomToolComponent],
     }),
   ],
 };

--- a/apps/ngx-dev-toolbar-demo/src/app/app.routes.ts
+++ b/apps/ngx-dev-toolbar-demo/src/app/app.routes.ts
@@ -34,4 +34,11 @@ export const appRoutes: Route[] = [
         (m) => m.I18nDemoComponent
       ),
   },
+  {
+    path: 'custom-tool',
+    loadComponent: () =>
+      import('./components/custom-tool-demo/custom-tool-demo.component').then(
+        (m) => m.CustomToolDemoComponent
+      ),
+  },
 ];

--- a/apps/ngx-dev-toolbar-demo/src/app/components/custom-tool-demo/custom-tool-demo.component.ts
+++ b/apps/ngx-dev-toolbar-demo/src/app/components/custom-tool-demo/custom-tool-demo.component.ts
@@ -1,0 +1,153 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+  selector: 'app-custom-tool-demo',
+  standalone: true,
+  template: `
+    <section class="custom-tool-demo">
+      <div class="demo-header">
+        <h2>Custom Tool</h2>
+        <p class="demo-description">
+          A demo toolbar tool showcasing the <code>ndt-tabs</code> component with Finder and Maker tabs.
+          Open the <strong>puzzle icon</strong> in the toolbar below to try it.
+        </p>
+      </div>
+
+      <div class="demo-card-grid">
+        <div class="demo-card">
+          <div class="card-header">
+            <h3>Finder Tab</h3>
+          </div>
+          <p class="card-description">
+            Search for application routes or DOM elements. Select a type from the dropdown
+            and click Find to see mock results.
+          </p>
+          <div class="card-preview">
+            <div class="preview-item"><code>/dashboard</code> — DashboardComponent</div>
+            <div class="preview-item"><code>/users/:id</code> — UserDetailComponent</div>
+            <div class="preview-item"><code>&lt;app-header&gt;</code> — 1 instance</div>
+          </div>
+        </div>
+
+        <div class="demo-card">
+          <div class="card-header">
+            <h3>Maker Tab</h3>
+          </div>
+          <p class="card-description">
+            Generate mock data entries on the fly. Select User, Order, or Product
+            and click Create to build sample records.
+          </p>
+          <div class="card-preview">
+            <div class="preview-item preview-item--green">Mock User #1 — 10:42:15 AM</div>
+            <div class="preview-item preview-item--green">Mock Order #2 — 10:42:18 AM</div>
+            <div class="preview-item preview-item--green">Mock Product #3 — 10:42:21 AM</div>
+          </div>
+        </div>
+      </div>
+    </section>
+  `,
+  styles: [`
+    .custom-tool-demo {
+      animation: fadeIn 0.3s ease;
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    .demo-header {
+      margin-bottom: 1.5rem;
+    }
+
+    .demo-header h2 {
+      margin: 0 0 0.5rem 0;
+      font-size: 1.5rem;
+      font-weight: 600;
+      color: var(--demo-text, #1e293b);
+    }
+
+    .demo-description {
+      margin: 0;
+      color: var(--demo-text-muted, #64748b);
+      font-size: 0.9375rem;
+    }
+
+    .demo-description code {
+      background: var(--demo-bg, #f1f5f9);
+      padding: 0.125rem 0.375rem;
+      border-radius: 4px;
+      font-size: 0.875rem;
+    }
+
+    .demo-card-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 1rem;
+    }
+
+    .demo-card {
+      background: var(--demo-card-bg, #ffffff);
+      border: 1px solid var(--demo-border, #e2e8f0);
+      border-radius: var(--demo-radius, 8px);
+      padding: 1.25rem;
+      box-shadow: var(--demo-shadow, 0 1px 3px rgba(0, 0, 0, 0.1));
+      transition: border-color 0.2s;
+    }
+
+    .demo-card:hover {
+      border-color: var(--demo-primary, #6366f1);
+    }
+
+    .card-header h3 {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--demo-text, #1e293b);
+    }
+
+    .card-description {
+      margin: 0.5rem 0 1rem 0;
+      font-size: 0.875rem;
+      color: var(--demo-text-muted, #64748b);
+      line-height: 1.5;
+    }
+
+    .card-preview {
+      display: flex;
+      flex-direction: column;
+      gap: 0.375rem;
+      padding: 0.75rem;
+      background: var(--demo-bg, #f8fafc);
+      border-radius: 6px;
+    }
+
+    .preview-item {
+      padding: 0.375rem 0.5rem;
+      background: white;
+      border-radius: 4px;
+      font-size: 0.8125rem;
+      color: var(--demo-text, #1e293b);
+      border-left: 2px solid #6366f1;
+    }
+
+    .preview-item--green {
+      border-left-color: #22c55e;
+    }
+
+    .preview-item code {
+      font-size: 0.75rem;
+      background: var(--demo-bg, #f1f5f9);
+      padding: 0.0625rem 0.25rem;
+      border-radius: 3px;
+    }
+
+    @media (max-width: 640px) {
+      .demo-card-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  `],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CustomToolDemoComponent {}

--- a/apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/custom-tool.component.ts
+++ b/apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/custom-tool.component.ts
@@ -1,0 +1,280 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  signal,
+} from '@angular/core';
+import {
+  SelectOption,
+  ToolbarButtonComponent,
+  ToolbarListComponent,
+  ToolbarSelectComponent,
+  ToolbarTabComponent,
+  ToolbarTabsComponent,
+  ToolbarToolComponent,
+  ToolbarWindowOptions,
+} from 'ngx-dev-toolbar';
+
+interface FinderResult {
+  id: string;
+  name: string;
+  detail: string;
+}
+
+const MOCK_ROUTES: FinderResult[] = [
+  { id: 'r1', name: '/dashboard', detail: 'DashboardComponent — lazy loaded' },
+  { id: 'r2', name: '/users', detail: 'UsersListComponent — eager' },
+  { id: 'r3', name: '/users/:id', detail: 'UserDetailComponent — lazy loaded' },
+  { id: 'r4', name: '/settings', detail: 'SettingsComponent — eager' },
+  { id: 'r5', name: '/reports', detail: 'ReportsComponent — lazy loaded' },
+];
+
+const MOCK_ELEMENTS: FinderResult[] = [
+  { id: 'e1', name: '<app-header>', detail: 'AppHeaderComponent — 1 instance' },
+  { id: 'e2', name: '<app-sidebar>', detail: 'SidebarComponent — 1 instance' },
+  { id: 'e3', name: '<ndt-toolbar>', detail: 'ToolbarComponent — 1 instance' },
+  { id: 'e4', name: '<app-card>', detail: 'CardComponent — 12 instances' },
+  { id: 'e5', name: '<app-button>', detail: 'ButtonComponent — 8 instances' },
+];
+
+interface CreatedEntry {
+  id: string;
+  type: string;
+  name: string;
+  timestamp: string;
+}
+
+@Component({
+  selector: 'ndt-custom-tool',
+  standalone: true,
+  imports: [
+    ToolbarToolComponent,
+    ToolbarTabsComponent,
+    ToolbarTabComponent,
+    ToolbarSelectComponent,
+    ToolbarButtonComponent,
+    ToolbarListComponent,
+  ],
+  template: `
+    <ndt-toolbar-tool [options]="options" toolTitle="Custom Tool" icon="terminal">
+      <div class="container">
+        <ndt-tabs>
+          <ndt-tab label="Finder">
+            <div class="action-row">
+              <ndt-select
+                [options]="finderOptions"
+                [(value)]="finderType"
+                placeholder="What to look for"
+                ariaLabel="Type to search for"
+              />
+              <ndt-button (click)="onFind()">Find</ndt-button>
+            </div>
+
+            <ndt-list
+              [hasItems]="finderResults().length > 0"
+              emptyMessage="Click Find to search"
+            >
+              @for (result of finderResults(); track result.id) {
+                <div class="finder-item">
+                  <a class="finder-item__link">{{ result.name }}</a>
+                  <span class="finder-item__detail">{{ result.detail }}</span>
+                </div>
+              }
+            </ndt-list>
+          </ndt-tab>
+
+          <ndt-tab label="Maker">
+            <div class="action-row">
+              <ndt-select
+                [options]="makerOptions"
+                [(value)]="makerType"
+                placeholder="What to create"
+                ariaLabel="Type to create"
+              />
+              <ndt-button (click)="onCreate()">Create</ndt-button>
+            </div>
+
+            <ndt-list
+              [hasItems]="createdEntries().length > 0"
+              emptyMessage="Click Create to generate mock data"
+            >
+              @for (entry of createdEntries(); track entry.id) {
+                <div class="maker-item">
+                  <div class="maker-item__header">
+                    <span class="maker-item__badge">{{ entry.type }}</span>
+                    <span class="maker-item__name">{{ entry.name }}</span>
+                  </div>
+                  <span class="maker-item__timestamp">{{ entry.timestamp }}</span>
+                </div>
+              }
+            </ndt-list>
+          </ndt-tab>
+        </ndt-tabs>
+      </div>
+    </ndt-toolbar-tool>
+  `,
+  styles: [
+    `
+      .container {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        padding: 0;
+      }
+
+      .action-row {
+        display: flex;
+        align-items: stretch;
+        gap: var(--ndt-spacing-sm);
+        margin-bottom: var(--ndt-spacing-md);
+        flex-shrink: 0;
+      }
+
+      .action-row ndt-select {
+        flex: 1 1 auto;
+        min-width: 120px;
+        max-width: 200px;
+        display: flex;
+      }
+
+      .action-row ndt-button {
+        flex: 0 0 auto;
+      }
+
+      /* Finder items */
+      .finder-item {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        padding: var(--ndt-spacing-xs) var(--ndt-spacing-sm);
+        background: var(--ndt-background-secondary);
+        border-radius: var(--ndt-border-radius-medium);
+        transition: background-color 0.2s ease;
+      }
+
+      .finder-item:hover {
+        background: var(--ndt-hover-bg);
+      }
+
+      .finder-item__link {
+        font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+        font-size: var(--ndt-font-size-xs);
+        font-weight: 500;
+        color: var(--ndt-primary);
+        cursor: pointer;
+        text-decoration: none;
+      }
+
+      .finder-item__link:hover {
+        text-decoration: underline;
+      }
+
+      .finder-item__detail {
+        font-size: var(--ndt-font-size-xxs);
+        color: var(--ndt-text-muted);
+      }
+
+      /* Maker items */
+      .maker-item {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        padding: var(--ndt-spacing-xs) var(--ndt-spacing-sm);
+        background: var(--ndt-background-secondary);
+        border-radius: var(--ndt-border-radius-medium);
+        border-left: 2px solid rgb(34, 197, 94);
+        transition: background-color 0.2s ease;
+      }
+
+      .maker-item:hover {
+        background: var(--ndt-hover-bg);
+      }
+
+      .maker-item__header {
+        display: flex;
+        align-items: center;
+        gap: var(--ndt-spacing-sm);
+      }
+
+      .maker-item__badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 1px var(--ndt-spacing-xs);
+        font-size: var(--ndt-font-size-xxs);
+        font-weight: 600;
+        color: rgb(34, 197, 94);
+        background: rgba(34, 197, 94, 0.1);
+        border-radius: var(--ndt-border-radius-small);
+        text-transform: uppercase;
+        letter-spacing: 0.02em;
+      }
+
+      .maker-item__name {
+        font-size: var(--ndt-font-size-sm);
+        font-weight: 500;
+        color: var(--ndt-text-primary);
+      }
+
+      .maker-item__timestamp {
+        font-size: var(--ndt-font-size-xxs);
+        color: var(--ndt-text-muted);
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ToolbarCustomToolComponent {
+  protected readonly options: ToolbarWindowOptions = {
+    id: 'ndt-custom-tool',
+    title: 'Custom Tool',
+    description: 'Find routes & elements, create mock data',
+    isClosable: true,
+    size: 'medium',
+  };
+
+  protected readonly finderOptions: SelectOption[] = [
+    { value: 'routes', label: 'Routes' },
+    { value: 'elements', label: 'Elements' },
+  ];
+
+  protected readonly makerOptions: SelectOption[] = [
+    { value: 'user', label: 'User' },
+    { value: 'order', label: 'Order' },
+    { value: 'product', label: 'Product' },
+  ];
+
+  readonly finderType = signal('routes');
+  readonly makerType = signal('user');
+  readonly finderResults = signal<FinderResult[]>([]);
+  readonly createdEntries = signal<CreatedEntry[]>([]);
+
+  private createdCount = 0;
+
+  onFind() {
+    const type = this.finderType();
+    if (type === 'routes') {
+      this.finderResults.set(MOCK_ROUTES);
+    } else if (type === 'elements') {
+      this.finderResults.set(MOCK_ELEMENTS);
+    }
+  }
+
+  onCreate() {
+    const type = this.makerType();
+    if (!type) return;
+
+    this.createdCount++;
+    const label = this.makerOptions.find((o) => o.value === type)?.label ?? type;
+    const now = new Date();
+    const timestamp = now.toLocaleTimeString();
+
+    this.createdEntries.update((entries) => [
+      {
+        id: `created-${this.createdCount}`,
+        type: label,
+        name: `Mock ${label} #${this.createdCount}`,
+        timestamp,
+      },
+      ...entries,
+    ]);
+  }
+}

--- a/apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/custom-tool.component.ts
+++ b/apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/custom-tool.component.ts
@@ -44,7 +44,7 @@ interface CreatedEntry {
 }
 
 @Component({
-  selector: 'ndt-custom-tool',
+  selector: 'app-custom-tool',
   standalone: true,
   imports: [
     ToolbarToolComponent,

--- a/apps/ngx-dev-toolbar-demo/src/app/components/sidebar/sidebar.component.ts
+++ b/apps/ngx-dev-toolbar-demo/src/app/components/sidebar/sidebar.component.ts
@@ -269,6 +269,12 @@ export class SidebarComponent {
       path: '/i18n',
       icon: '<circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>',
     },
+    {
+      id: 'custom-tool',
+      label: 'Custom Tool',
+      path: '/custom-tool',
+      icon: '<path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>',
+    },
   ];
 
   private readonly forcedFlags = toSignal(this.flagsService.getForcedValues(), {

--- a/libs/ngx-dev-toolbar/src/components/list-item/list-item.component.scss
+++ b/libs/ngx-dev-toolbar/src/components/list-item/list-item.component.scss
@@ -25,6 +25,7 @@
 .list-item .info {
   flex: 1 1 auto;
   min-width: 0;
+  padding-left: var(--ndt-spacing-xs);
 }
 
 .list-item .info h3 {

--- a/libs/ngx-dev-toolbar/src/components/select/select.component.ts
+++ b/libs/ngx-dev-toolbar/src/components/select/select.component.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   computed,
   inject,
   input,
@@ -49,6 +50,7 @@ export interface SelectOption {
       [cdkConnectedOverlayOrigin]="trigger"
       [cdkConnectedOverlayOpen]="isOpen()"
       [cdkConnectedOverlayPositions]="positions"
+      [cdkConnectedOverlayMinWidth]="triggerWidth()"
       [cdkConnectedOverlayPanelClass]="['ndt-overlay-panel', 'ndt-select-overlay']"
       (overlayOutsideClick)="close()"
     >
@@ -78,6 +80,7 @@ export interface SelectOption {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ToolbarSelectComponent {
+  private readonly elementRef = inject(ElementRef);
   readonly devToolbarStateService = inject(ToolbarStateService);
 
   value = model<string>();
@@ -92,6 +95,7 @@ export class ToolbarSelectComponent {
     .toString(36)
     .slice(2, 11)}`;
   isOpen = signal(false);
+  triggerWidth = signal(0);
 
   isPlaceholder = computed(() => {
     const options = this.options();
@@ -121,6 +125,8 @@ export class ToolbarSelectComponent {
   ];
 
   toggle() {
+    const selectEl = this.elementRef.nativeElement.querySelector('.ndt-select');
+    this.triggerWidth.set(selectEl?.offsetWidth ?? 0);
     this.isOpen.update((v) => !v);
   }
 

--- a/libs/ngx-dev-toolbar/src/components/tabs/tab.component.ts
+++ b/libs/ngx-dev-toolbar/src/components/tabs/tab.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component, input, signal } from '@angular/core';
+
+@Component({
+  selector: 'ndt-tab',
+  standalone: true,
+  template: `
+    @if (isActive()) {
+      <ng-content />
+    }
+  `,
+  styles: `
+    :host {
+      display: block;
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ToolbarTabComponent {
+  readonly label = input.required<string>();
+  readonly isActive = signal(false);
+}

--- a/libs/ngx-dev-toolbar/src/components/tabs/tabs.component.scss
+++ b/libs/ngx-dev-toolbar/src/components/tabs/tabs.component.scss
@@ -1,0 +1,50 @@
+:host {
+  display: flex;
+  flex-direction: column;
+}
+
+.tab-bar {
+  display: flex;
+  gap: var(--ndt-spacing-xs);
+  padding: 0;
+  margin: 0;
+  border-bottom: 1px solid var(--ndt-border-primary);
+  flex-shrink: 0;
+}
+
+.tab-button {
+  all: unset;
+  display: inline-flex;
+  align-items: center;
+  padding: var(--ndt-spacing-sm) var(--ndt-spacing-md);
+  font-size: var(--ndt-font-size-sm);
+  font-weight: 500;
+  color: var(--ndt-text-secondary);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s ease, border-color 0.15s ease;
+  box-sizing: border-box;
+
+  &:hover {
+    color: var(--ndt-text-primary);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--ndt-text-primary);
+    outline-offset: -2px;
+    border-radius: var(--ndt-border-radius-small);
+  }
+
+  &--active {
+    color: var(--ndt-text-primary);
+    border-bottom-color: var(--ndt-text-primary);
+    font-weight: 600;
+  }
+}
+
+.tab-panel {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding-top: var(--ndt-spacing-md);
+}

--- a/libs/ngx-dev-toolbar/src/components/tabs/tabs.component.spec.ts
+++ b/libs/ngx-dev-toolbar/src/components/tabs/tabs.component.spec.ts
@@ -1,0 +1,144 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ToolbarTabsComponent } from './tabs.component';
+import { ToolbarTabComponent } from './tab.component';
+
+@Component({
+  standalone: true,
+  imports: [ToolbarTabsComponent, ToolbarTabComponent],
+  template: `
+    <ndt-tabs>
+      <ndt-tab label="First">First content</ndt-tab>
+      <ndt-tab label="Second">Second content</ndt-tab>
+      <ndt-tab label="Third">Third content</ndt-tab>
+    </ndt-tabs>
+  `,
+})
+class TestHostComponent {}
+
+describe('ToolbarTabsComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let el: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+    el = fixture.nativeElement;
+  });
+
+  it('should render tab buttons for each tab', () => {
+    const buttons = el.querySelectorAll('[role="tab"]');
+    expect(buttons.length).toBe(3);
+    expect(buttons[0].textContent?.trim()).toBe('First');
+    expect(buttons[1].textContent?.trim()).toBe('Second');
+    expect(buttons[2].textContent?.trim()).toBe('Third');
+  });
+
+  it('should show the first tab content by default', () => {
+    expect(el.textContent).toContain('First content');
+    expect(el.textContent).not.toContain('Second content');
+    expect(el.textContent).not.toContain('Third content');
+  });
+
+  it('should have aria-selected on the active tab', () => {
+    const buttons = el.querySelectorAll('[role="tab"]');
+    expect(buttons[0].getAttribute('aria-selected')).toBe('true');
+    expect(buttons[1].getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('should switch tabs on click', () => {
+    const buttons = el.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    buttons[1].click();
+    fixture.detectChanges();
+
+    expect(el.textContent).not.toContain('First content');
+    expect(el.textContent).toContain('Second content');
+    expect(buttons[1].getAttribute('aria-selected')).toBe('true');
+    expect(buttons[0].getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('should have tablist role on container', () => {
+    const tablist = el.querySelector('[role="tablist"]');
+    expect(tablist).toBeTruthy();
+  });
+
+  it('should have tabpanel role on content area', () => {
+    const panel = el.querySelector('[role="tabpanel"]');
+    expect(panel).toBeTruthy();
+  });
+
+  it('should navigate to next tab on ArrowRight', () => {
+    const buttons = el.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    buttons[0].dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true })
+    );
+    fixture.detectChanges();
+
+    expect(el.textContent).toContain('Second content');
+    expect(buttons[1].getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('should navigate to previous tab on ArrowLeft', () => {
+    // First go to tab 2
+    const buttons = el.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    buttons[1].click();
+    fixture.detectChanges();
+
+    buttons[1].dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true })
+    );
+    fixture.detectChanges();
+
+    expect(el.textContent).toContain('First content');
+    expect(buttons[0].getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('should wrap around on ArrowRight from last tab', () => {
+    const buttons = el.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    buttons[2].click();
+    fixture.detectChanges();
+
+    buttons[2].dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true })
+    );
+    fixture.detectChanges();
+
+    expect(el.textContent).toContain('First content');
+    expect(buttons[0].getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('should set tabindex 0 on active tab and -1 on others', () => {
+    const buttons = el.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    expect(buttons[0].getAttribute('tabindex')).toBe('0');
+    expect(buttons[1].getAttribute('tabindex')).toBe('-1');
+    expect(buttons[2].getAttribute('tabindex')).toBe('-1');
+  });
+});
+
+describe('ToolbarTabComponent', () => {
+  let fixture: ComponentFixture<ToolbarTabComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ToolbarTabComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ToolbarTabComponent);
+    fixture.componentRef.setInput('label', 'Test Tab');
+    fixture.detectChanges();
+  });
+
+  it('should be defined', () => {
+    expect(fixture.componentInstance).toBeDefined();
+  });
+
+  it('should not render content when inactive', () => {
+    fixture.componentInstance.isActive.set(false);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent.trim()).toBe('');
+  });
+});

--- a/libs/ngx-dev-toolbar/src/components/tabs/tabs.component.ts
+++ b/libs/ngx-dev-toolbar/src/components/tabs/tabs.component.ts
@@ -1,0 +1,93 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  contentChildren,
+  effect,
+  output,
+  signal,
+} from '@angular/core';
+import { ToolbarTabComponent } from './tab.component';
+
+@Component({
+  selector: 'ndt-tabs',
+  standalone: true,
+  template: `
+    <div class="tab-bar" role="tablist">
+      @for (tab of tabs(); track $index) {
+        <button
+          class="tab-button"
+          [class.tab-button--active]="$index === activeIndex()"
+          role="tab"
+          [attr.aria-selected]="$index === activeIndex()"
+          [attr.tabindex]="$index === activeIndex() ? 0 : -1"
+          [attr.id]="'tab-' + instanceId + '-' + $index"
+          [attr.aria-controls]="'tabpanel-' + instanceId"
+          (click)="selectTab($index)"
+          (keydown)="onKeydown($event, $index)"
+        >
+          {{ tab.label() }}
+        </button>
+      }
+    </div>
+    <div
+      class="tab-panel"
+      role="tabpanel"
+      [attr.id]="'tabpanel-' + instanceId"
+      [attr.aria-labelledby]="'tab-' + instanceId + '-' + activeIndex()"
+    >
+      <ng-content />
+    </div>
+  `,
+  styleUrl: './tabs.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ToolbarTabsComponent {
+  readonly tabs = contentChildren(ToolbarTabComponent);
+  readonly activeIndex = signal(0);
+  readonly activeIndexChange = output<number>();
+
+  protected readonly instanceId = Math.random().toString(36).slice(2, 9);
+
+  constructor() {
+    effect(() => {
+      const tabs = this.tabs();
+      const active = this.activeIndex();
+      tabs.forEach((tab, i) => tab.isActive.set(i === active));
+    });
+  }
+
+  selectTab(index: number) {
+    this.activeIndex.set(index);
+    this.activeIndexChange.emit(index);
+  }
+
+  onKeydown(event: KeyboardEvent, currentIndex: number) {
+    const count = this.tabs().length;
+    let newIndex: number | null = null;
+
+    switch (event.key) {
+      case 'ArrowRight':
+        newIndex = (currentIndex + 1) % count;
+        break;
+      case 'ArrowLeft':
+        newIndex = (currentIndex - 1 + count) % count;
+        break;
+      case 'Home':
+        newIndex = 0;
+        break;
+      case 'End':
+        newIndex = count - 1;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    this.selectTab(newIndex);
+
+    const button = (event.target as HTMLElement)
+      .parentElement?.querySelectorAll<HTMLButtonElement>('[role="tab"]')
+      [newIndex];
+    button?.focus();
+  }
+}

--- a/libs/ngx-dev-toolbar/src/index.ts
+++ b/libs/ngx-dev-toolbar/src/index.ts
@@ -27,6 +27,8 @@ export * from './components/clickable-card/clickable-card.component';
 export * from './components/link-button/link-button.component';
 export * from './components/step-view/step-view.component';
 export * from './components/step-view/step-view.directive';
+export * from './components/tabs/tab.component';
+export * from './components/tabs/tabs.component';
 
 export * from './toolbar.component';
 export * from './models/toolbar.interface';
@@ -53,3 +55,4 @@ export * from './tools/permissions-tool/permissions-tool.component';
 export * from './tools/presets-tool/presets.models';
 export * from './tools/presets-tool/presets.service';
 export * from './tools/presets-tool/presets-tool.component';
+

--- a/libs/ngx-dev-toolbar/src/models/toolbar-config.interface.ts
+++ b/libs/ngx-dev-toolbar/src/models/toolbar-config.interface.ts
@@ -1,3 +1,4 @@
+import { Type } from '@angular/core';
 import { ToolbarPosition } from './toolbar-position.model';
 
 /**
@@ -49,6 +50,21 @@ export interface ToolbarConfig {
    * @default true
    */
   showPresetsTool?: boolean;
+
+  /**
+   * Custom tool components to render inside the toolbar.
+   *
+   * Each component should use `ToolbarToolComponent` as its wrapper
+   * and will appear as an icon in the toolbar strip alongside built-in tools.
+   *
+   * @example
+   * ```typescript
+   * provideToolbar({
+   *   customTools: [MyFinderTool, MyDebugTool],
+   * })
+   * ```
+   */
+  customTools?: Type<unknown>[];
 
   /**
    * Callback to persist a forced feature flag value to the actual source.

--- a/libs/ngx-dev-toolbar/src/provide-toolbar.spec.ts
+++ b/libs/ngx-dev-toolbar/src/provide-toolbar.spec.ts
@@ -4,23 +4,23 @@ import { provideToolbar } from './provide-toolbar';
 import { TOOLBAR_CONFIG, TOOLBAR_CUSTOM_TOOLS } from './tokens';
 
 @Component({ standalone: true, selector: 'ndt-fake-tool', template: '' })
-class FakeToolA {}
+class FakeToolAComponent {}
 
 @Component({ standalone: true, selector: 'ndt-fake-tool-b', template: '' })
-class FakeToolB {}
+class FakeToolBComponent {}
 
 describe('provideToolbar', () => {
   it('should provide TOOLBAR_CUSTOM_TOOLS with registered components', () => {
     TestBed.configureTestingModule({
       providers: [
         provideToolbar({
-          customTools: [FakeToolA, FakeToolB],
+          customTools: [FakeToolAComponent, FakeToolBComponent],
         }),
       ],
     });
 
     const customTools = TestBed.inject(TOOLBAR_CUSTOM_TOOLS);
-    expect(customTools).toEqual([FakeToolA, FakeToolB]);
+    expect(customTools).toEqual([FakeToolAComponent, FakeToolBComponent]);
   });
 
   it('should provide empty array when no custom tools specified', () => {
@@ -46,14 +46,15 @@ describe('provideToolbar', () => {
       providers: [
         provideToolbar({
           showI18nTool: true,
-          customTools: [FakeToolA],
+          customTools: [FakeToolAComponent],
         }),
       ],
     });
 
     const config = TestBed.inject(TOOLBAR_CONFIG);
     expect(config.showI18nTool).toBe(true);
-    expect((config as any).customTools).toBeUndefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((config as Record<string, any>)['customTools']).toBeUndefined();
   });
 
   it('should preserve all config flags when customTools is provided', () => {
@@ -66,7 +67,7 @@ describe('provideToolbar', () => {
           showAppFeaturesTool: true,
           showPermissionsTool: false,
           showPresetsTool: true,
-          customTools: [FakeToolA],
+          customTools: [FakeToolAComponent],
         }),
       ],
     });

--- a/libs/ngx-dev-toolbar/src/provide-toolbar.spec.ts
+++ b/libs/ngx-dev-toolbar/src/provide-toolbar.spec.ts
@@ -1,0 +1,84 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideToolbar } from './provide-toolbar';
+import { TOOLBAR_CONFIG, TOOLBAR_CUSTOM_TOOLS } from './tokens';
+
+@Component({ standalone: true, selector: 'ndt-fake-tool', template: '' })
+class FakeToolA {}
+
+@Component({ standalone: true, selector: 'ndt-fake-tool-b', template: '' })
+class FakeToolB {}
+
+describe('provideToolbar', () => {
+  it('should provide TOOLBAR_CUSTOM_TOOLS with registered components', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideToolbar({
+          customTools: [FakeToolA, FakeToolB],
+        }),
+      ],
+    });
+
+    const customTools = TestBed.inject(TOOLBAR_CUSTOM_TOOLS);
+    expect(customTools).toEqual([FakeToolA, FakeToolB]);
+  });
+
+  it('should provide empty array when no custom tools specified', () => {
+    TestBed.configureTestingModule({
+      providers: [provideToolbar({})],
+    });
+
+    const customTools = TestBed.inject(TOOLBAR_CUSTOM_TOOLS);
+    expect(customTools).toEqual([]);
+  });
+
+  it('should provide empty array when config is undefined', () => {
+    TestBed.configureTestingModule({
+      providers: [provideToolbar()],
+    });
+
+    const customTools = TestBed.inject(TOOLBAR_CUSTOM_TOOLS);
+    expect(customTools).toEqual([]);
+  });
+
+  it('should not include customTools in TOOLBAR_CONFIG', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideToolbar({
+          showI18nTool: true,
+          customTools: [FakeToolA],
+        }),
+      ],
+    });
+
+    const config = TestBed.inject(TOOLBAR_CONFIG);
+    expect(config.showI18nTool).toBe(true);
+    expect((config as any).customTools).toBeUndefined();
+  });
+
+  it('should preserve all config flags when customTools is provided', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideToolbar({
+          enabled: true,
+          showI18nTool: true,
+          showFeatureFlagsTool: false,
+          showAppFeaturesTool: true,
+          showPermissionsTool: false,
+          showPresetsTool: true,
+          customTools: [FakeToolA],
+        }),
+      ],
+    });
+
+    const config = TestBed.inject(TOOLBAR_CONFIG);
+    expect(config).toEqual({
+      enabled: true,
+      showI18nTool: true,
+      showFeatureFlagsTool: false,
+      showAppFeaturesTool: true,
+      showPermissionsTool: false,
+      showPresetsTool: true,
+    });
+  });
+});

--- a/libs/ngx-dev-toolbar/src/provide-toolbar.ts
+++ b/libs/ngx-dev-toolbar/src/provide-toolbar.ts
@@ -12,6 +12,7 @@ import { ToolbarConfig } from './models/toolbar-config.interface';
 import {
   TOOLBAR_APP_FEATURES,
   TOOLBAR_CONFIG,
+  TOOLBAR_CUSTOM_TOOLS,
   TOOLBAR_FEATURE_FLAGS,
   TOOLBAR_PERMISSIONS,
 } from './tokens';
@@ -83,11 +84,14 @@ import { ToolbarInternalAppFeaturesService } from './tools/app-features-tool/app
  * @returns Angular EnvironmentProviders for all toolbar services
  */
 export function provideToolbar(config?: ToolbarConfig): EnvironmentProviders {
+  const { customTools, ...configWithoutTools } = config ?? {};
+
   return makeEnvironmentProviders([
     { provide: TOOLBAR_FEATURE_FLAGS, useClass: ToolbarFeatureFlagService },
     { provide: TOOLBAR_PERMISSIONS, useClass: ToolbarPermissionsService },
     { provide: TOOLBAR_APP_FEATURES, useClass: ToolbarAppFeaturesService },
-    { provide: TOOLBAR_CONFIG, useValue: config ?? {} },
+    { provide: TOOLBAR_CONFIG, useValue: configWithoutTools },
+    { provide: TOOLBAR_CUSTOM_TOOLS, useValue: customTools ?? [] },
     {
       provide: ENVIRONMENT_INITIALIZER,
       multi: true,

--- a/libs/ngx-dev-toolbar/src/tokens.ts
+++ b/libs/ngx-dev-toolbar/src/tokens.ts
@@ -1,4 +1,4 @@
-import { InjectionToken } from '@angular/core';
+import { InjectionToken, Type } from '@angular/core';
 import { ToolbarConfig } from './models/toolbar-config.interface';
 import { ToolbarService } from './models/toolbar.interface';
 import { ToolbarAppFeature } from './tools/app-features-tool/app-features.models';
@@ -74,3 +74,29 @@ export const TOOLBAR_PERMISSIONS = new InjectionToken<
 export const TOOLBAR_APP_FEATURES = new InjectionToken<
   ToolbarService<ToolbarAppFeature>
 >('TOOLBAR_APP_FEATURES');
+
+/**
+ * InjectionToken for registering custom tool components with the toolbar.
+ *
+ * Custom tools are Angular components that extend the toolbar with app-specific
+ * functionality. They are dynamically rendered inside the toolbar at runtime.
+ *
+ * Use `provideToolbarCustomTools()` to register custom tool components.
+ *
+ * @example
+ * ```typescript
+ * // app.config.ts
+ * import { provideToolbar, provideToolbarCustomTools } from 'ngx-dev-toolbar';
+ * import { MyCustomToolComponent } from './my-custom-tool.component';
+ *
+ * export const appConfig: ApplicationConfig = {
+ *   providers: [
+ *     provideToolbar({ ... }),
+ *     provideToolbarCustomTools(MyCustomToolComponent),
+ *   ],
+ * };
+ * ```
+ */
+export const TOOLBAR_CUSTOM_TOOLS = new InjectionToken<Type<unknown>[]>(
+  'TOOLBAR_CUSTOM_TOOLS'
+);

--- a/libs/ngx-dev-toolbar/src/toolbar.component.spec.ts
+++ b/libs/ngx-dev-toolbar/src/toolbar.component.spec.ts
@@ -1,0 +1,126 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
+import { ToolbarComponent } from './toolbar.component';
+import { ToolbarStateService } from './toolbar-state.service';
+import { ToolbarStorageService } from './utils/storage.service';
+import { TOOLBAR_CUSTOM_TOOLS } from './tokens';
+import { SettingsService } from './tools/home-tool/settings.service';
+
+@Component({
+  standalone: true,
+  selector: 'ndt-mock-custom-tool',
+  template: '<div class="mock-custom-tool">Custom Tool Rendered</div>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class MockCustomToolComponent {}
+
+@Component({
+  standalone: true,
+  selector: 'ndt-mock-custom-tool-b',
+  template: '<div class="mock-custom-tool-b">Second Tool Rendered</div>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class MockCustomToolBComponent {}
+
+function createMockStateService() {
+  return {
+    theme: signal('light' as 'light' | 'dark'),
+    isEnabled: signal(true),
+    activeToolId: signal<string | null>(null),
+    position: signal('bottom' as const),
+    isHidden: signal(false),
+    isVisible: signal(true),
+    isCompletelyHidden: signal(false),
+    hasActiveTool: signal(false),
+    delay: signal(3000),
+    config: signal({}),
+    setConfig: jest.fn(),
+    setVisibility: jest.fn(),
+    setTheme: jest.fn(),
+    toggleCompletelyHidden: jest.fn(),
+  };
+}
+
+function createMockStorageService() {
+  return {
+    get: jest.fn().mockReturnValue(null),
+    set: jest.fn(),
+    remove: jest.fn(),
+  };
+}
+
+function createMockSettingsService() {
+  return {
+    loadSettings: jest.fn(),
+  };
+}
+
+describe('ToolbarComponent — custom tools', () => {
+  let fixture: ComponentFixture<ToolbarComponent>;
+
+  function setup(customTools: any[] = []) {
+    TestBed.configureTestingModule({
+      imports: [ToolbarComponent],
+      providers: [
+        { provide: TOOLBAR_CUSTOM_TOOLS, useValue: customTools },
+        { provide: ToolbarStateService, useValue: createMockStateService() },
+        { provide: ToolbarStorageService, useValue: createMockStorageService() },
+        { provide: SettingsService, useValue: createMockSettingsService() },
+      ],
+    });
+
+    fixture = TestBed.createComponent(ToolbarComponent);
+    fixture.componentRef.setInput('config', {});
+    fixture.detectChanges();
+    flush();
+    fixture.detectChanges();
+  }
+
+  it('should render a single custom tool component', fakeAsync(() => {
+    setup([MockCustomToolComponent]);
+
+    const shadowRoot = fixture.nativeElement.shadowRoot;
+    const customTool = shadowRoot?.querySelector('ndt-mock-custom-tool');
+    expect(customTool).toBeTruthy();
+    expect(customTool?.textContent).toContain('Custom Tool Rendered');
+  }));
+
+  it('should render multiple custom tool components', fakeAsync(() => {
+    setup([MockCustomToolComponent, MockCustomToolBComponent]);
+
+    const shadowRoot = fixture.nativeElement.shadowRoot;
+    const toolA = shadowRoot?.querySelector('ndt-mock-custom-tool');
+    const toolB = shadowRoot?.querySelector('ndt-mock-custom-tool-b');
+    expect(toolA).toBeTruthy();
+    expect(toolB).toBeTruthy();
+  }));
+
+  it('should render no custom tools when token is empty', fakeAsync(() => {
+    setup([]);
+
+    const shadowRoot = fixture.nativeElement.shadowRoot;
+    const customTool = shadowRoot?.querySelector('ndt-mock-custom-tool');
+    expect(customTool).toBeNull();
+  }));
+
+  it('should render no custom tools when token is not provided', fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [ToolbarComponent],
+      providers: [
+        { provide: ToolbarStateService, useValue: createMockStateService() },
+        { provide: ToolbarStorageService, useValue: createMockStorageService() },
+        { provide: SettingsService, useValue: createMockSettingsService() },
+      ],
+    });
+
+    fixture = TestBed.createComponent(ToolbarComponent);
+    fixture.componentRef.setInput('config', {});
+    fixture.detectChanges();
+    flush();
+    fixture.detectChanges();
+
+    const shadowRoot = fixture.nativeElement.shadowRoot;
+    const customTool = shadowRoot?.querySelector('ndt-mock-custom-tool');
+    expect(customTool).toBeNull();
+  }));
+});

--- a/libs/ngx-dev-toolbar/src/toolbar.component.spec.ts
+++ b/libs/ngx-dev-toolbar/src/toolbar.component.spec.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal, Type } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
 import { ToolbarComponent } from './toolbar.component';
 import { ToolbarStateService } from './toolbar-state.service';
@@ -58,7 +58,7 @@ function createMockSettingsService() {
 describe('ToolbarComponent — custom tools', () => {
   let fixture: ComponentFixture<ToolbarComponent>;
 
-  function setup(customTools: any[] = []) {
+  function setup(customTools: Type<unknown>[] = []) {
     TestBed.configureTestingModule({
       imports: [ToolbarComponent],
       providers: [

--- a/libs/ngx-dev-toolbar/src/toolbar.component.ts
+++ b/libs/ngx-dev-toolbar/src/toolbar.component.ts
@@ -5,16 +5,19 @@ import {
   DestroyRef,
   OnDestroy,
   OnInit,
+  ViewContainerRef,
   ViewEncapsulation,
   effect,
   inject,
   input,
+  viewChild,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { fromEvent } from 'rxjs';
 import { filter, throttleTime } from 'rxjs/operators';
 import { ToolbarStateService } from './toolbar-state.service';
 import { ToolbarConfig } from './models/toolbar-config.interface';
+import { TOOLBAR_CUSTOM_TOOLS } from './tokens';
 import { ToolbarAppFeaturesToolComponent } from './tools/app-features-tool/app-features-tool.component';
 import { ToolbarFeatureFlagsToolComponent } from './tools/feature-flags-tool/feature-flags-tool.component';
 import { ToolbarHomeToolComponent } from './tools/home-tool/home-tool.component';
@@ -53,6 +56,7 @@ import { ToolbarPresetsToolComponent } from './tools/presets-tool/presets-tool.c
       >
         <ndt-home-tool />
         <ng-content />
+        <ng-container #customTools />
         @if (config().showI18nTool ?? false) {
           <ndt-i18n-tool />
         }
@@ -77,6 +81,8 @@ export class ToolbarComponent implements OnInit, OnDestroy {
   state = inject(ToolbarStateService);
   destroyRef = inject(DestroyRef);
   settingsService = inject(SettingsService);
+  private customToolTypes = inject(TOOLBAR_CUSTOM_TOOLS, { optional: true }) ?? [];
+  private customToolsContainer = viewChild('customTools', { read: ViewContainerRef });
 
   config = input<ToolbarConfig>({});
   private globalStyleElement?: HTMLStyleElement;
@@ -111,6 +117,16 @@ export class ToolbarComponent implements OnInit, OnDestroy {
     // Update state service when config changes
     effect(() => {
       this.state.setConfig(this.config());
+    });
+
+    // Dynamically render registered custom tool components
+    effect(() => {
+      const container = this.customToolsContainer();
+      if (container && container.length === 0 && this.customToolTypes.length > 0) {
+        for (const toolType of this.customToolTypes) {
+          container.createComponent(toolType);
+        }
+      }
     });
   }
 

--- a/specs/014-tab-component-custom-tool/.spec-context.json
+++ b/specs/014-tab-component-custom-tool/.spec-context.json
@@ -1,0 +1,13 @@
+{
+  "workflow": "sdd",
+  "selectedAt": "2026-04-10T12:00:00.000Z",
+  "currentStep": "specify",
+  "status": "active",
+  "specName": "Tab Component & Custom Tool Demo",
+  "branch": "main",
+  "stepHistory": {
+    "specify": {
+      "startedAt": "2026-04-10T12:00:00.000Z"
+    }
+  }
+}

--- a/specs/014-tab-component-custom-tool/plan.md
+++ b/specs/014-tab-component-custom-tool/plan.md
@@ -1,0 +1,98 @@
+# Plan: Tab Component & Custom Tool Demo
+
+**Spec**: 014-tab-component-custom-tool | **Date**: 2026-04-10
+
+---
+
+## Approach
+
+Build a reusable `ndt-tabs` / `ndt-tab` component pair in the library's component system, following the same standalone + OnPush + signal-based patterns as existing components (card, step-view, select). Then create a custom tool demo in the demo app that uses these tabs to showcase Finder and Maker views with `ndt-select`, `ndt-button`, and `ndt-list-item`.
+
+The tab component uses Angular's `contentChildren` query to discover `ndt-tab` children, tracks the active index via a signal, and projects only the active tab's content. This mirrors how `ndt-step-view` already manages multi-step content but with a horizontal tab bar instead of step navigation.
+
+---
+
+## Technical Context
+
+- **Component pattern**: Standalone, OnPush, `input()`/`output()` functions, signals for state, inline templates for small components.
+- **Content projection**: `contentChildren(ToolbarTabComponent)` to discover tabs, similar to `step-view` discovering `ndtStep` directives.
+- **Styling**: SCSS with `--ndt-*` design tokens, defensive CSS (explicit spacing, `gap`, no browser-default reliance).
+- **Keyboard a11y**: `role="tablist"` / `role="tab"` / `role="tabpanel"`, arrow key navigation, `aria-selected`.
+
+---
+
+## Flow
+
+```
+┌─────────────────────────────────────────┐
+│ ndt-tabs                                │
+│ ┌──────────┬──────────┬───────────────┐ │
+│ │ Tab 1 ●  │ Tab 2    │ ...           │ │  ← tab bar (role="tablist")
+│ └──────────┴──────────┴───────────────┘ │
+│ ┌─────────────────────────────────────┐ │
+│ │                                     │ │
+│ │  <ng-content> of active ndt-tab     │ │  ← tab panel (role="tabpanel")
+│ │                                     │ │
+│ └─────────────────────────────────────┘ │
+└─────────────────────────────────────────┘
+```
+
+---
+
+## Files to Create
+
+| # | Path | Purpose |
+|---|------|---------|
+| 1 | `libs/ngx-dev-toolbar/src/components/tabs/tabs.component.ts` | `ToolbarTabsComponent` — container with tab bar + content switching |
+| 2 | `libs/ngx-dev-toolbar/src/components/tabs/tabs.component.scss` | Tab bar and panel styling using design tokens |
+| 3 | `libs/ngx-dev-toolbar/src/components/tabs/tab.component.ts` | `ToolbarTabComponent` — individual tab with `label` input and content projection |
+| 4 | `apps/ngx-dev-toolbar-demo/src/app/components/custom-tool-demo/custom-tool-demo.component.ts` | Demo custom tool using tabs (Finder + Maker) |
+| 5 | `apps/ngx-dev-toolbar-demo/src/app/components/custom-tool-demo/custom-tool-demo.component.scss` | Styles for the custom tool demo |
+
+## Files to Modify
+
+| # | Path | Change |
+|---|------|--------|
+| 1 | `libs/ngx-dev-toolbar/src/index.ts` | Export `ToolbarTabsComponent` and `ToolbarTabComponent` |
+| 2 | `apps/ngx-dev-toolbar-demo/src/app/app.component.ts` | Import and render the custom tool demo component |
+
+---
+
+## Implementation Notes
+
+### Tab Component Design
+
+- **`ToolbarTabComponent`**: Minimal component with a `label` input (string) and an `isActive` signal (set by parent). Uses `@if (isActive())` to conditionally render its `<ng-content>`.
+- **`ToolbarTabsComponent`**: Uses `contentChildren(ToolbarTabComponent)` to query children. Maintains `activeIndex = signal(0)`. On tab click, sets the new active index and updates each child's `isActive` accordingly via an `effect()`.
+- **Tab bar**: Rendered from the tab children's labels. Active tab gets a bottom border highlight using `--ndt-text-primary` color and `--ndt-border-primary`.
+
+### Keyboard Navigation (R008)
+
+- Tab bar buttons use `role="tab"` with `aria-selected`.
+- Left/Right arrow keys move focus between tabs.
+- Enter/Space activates the focused tab.
+- Panel uses `role="tabpanel"` with `aria-labelledby` linking to the active tab.
+
+### Custom Tool Demo
+
+- Registers as a custom tool using `ToolbarToolComponent` wrapper with an icon and title.
+- **Finder tab**: `ndt-select` with entity types + `ndt-button` "Find" in a row. Below, an `ndt-list` with `ndt-list-item` entries populated from mock data on button click.
+- **Maker tab**: `ndt-select` with entity types + `ndt-button` "Create" in a row. Placeholder content below for future expansion.
+- Mock data stored as simple arrays in the component file (no service needed for demo).
+
+### Defensive CSS
+
+- Tab bar: `display: flex; gap: var(--ndt-spacing-sm);` with explicit padding.
+- Tab buttons: explicit `padding`, `border: none`, `background: transparent`, `cursor: pointer`.
+- Active indicator: `border-bottom: 2px solid var(--ndt-text-primary)` on active tab.
+- Panel: `padding-top: var(--ndt-spacing-md)` to prevent content touching tab bar.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| `contentChildren` timing — tabs might not be available in `ngOnInit` | Use `afterNextRender` or `effect()` to react to children changes; `contentChildren` with signals updates automatically |
+| Tab content re-mounting on switch could lose state | Use `@if` for simplicity (per spec: no state preservation needed); document that lazy rendering is out of scope |
+| Demo app import path changes | Use `ngx-dev-toolbar` package import, not relative paths |

--- a/specs/014-tab-component-custom-tool/spec.md
+++ b/specs/014-tab-component-custom-tool/spec.md
@@ -1,0 +1,67 @@
+# Spec: Tab Component & Custom Tool Demo
+
+**Slug**: 014-tab-component-custom-tool | **Date**: 2026-04-10
+
+## Summary
+
+Create a reusable `ndt-tabs` / `ndt-tab` component for the library's component system and use it in the demo app's custom tool to showcase two tabs: **Finder** (look up entities/links) and **Maker** (create entities/data). The tab component follows existing patterns (standalone, OnPush, signal-based) and is exported from the public API.
+
+## Requirements
+
+### Tab Component
+
+- **R001** (MUST): Create `ToolbarTabsComponent` (`ndt-tabs`) that accepts multiple `ndt-tab` children and renders a tab bar + content area
+- **R002** (MUST): Create `ToolbarTabComponent` (`ndt-tab`) with `label` input and content projection for tab body
+- **R003** (MUST): Only the active tab's content is rendered (or visually hidden); switching tabs updates which content is shown
+- **R004** (MUST): Active tab is visually highlighted in the tab bar using existing design tokens (`--ndt-*` variables)
+- **R005** (MUST): Components are standalone, use OnPush change detection, and follow signal-based state patterns
+- **R006** (MUST): Export both components from `libs/ngx-dev-toolbar/src/index.ts`
+- **R007** (SHOULD): Tab bar uses defensive CSS patterns (explicit spacing, no reliance on browser defaults)
+- **R008** (SHOULD): Support keyboard navigation between tabs (arrow keys, Enter/Space to select)
+
+### Custom Tool Demo — Finder Tab
+
+- **R009** (MUST): Finder tab contains a select dropdown ("What to look for") with sample entity types (e.g., User, Order, Product)
+- **R010** (MUST): Finder tab contains a "Find" button next to the select
+- **R011** (MUST): Below the select/button row, display a results area using `ndt-list-item` components with placeholder/sample results
+- **R012** (SHOULD): Clicking "Find" populates the results list with mock data matching the selected type
+
+### Custom Tool Demo — Maker Tab
+
+- **R013** (MUST): Maker tab contains a select dropdown ("What to create") with sample entity types
+- **R014** (MUST): Maker tab contains an "Add/Create" button next to the select
+- **R015** (MAY): Maker tab can show placeholder content below for future component demos (data entry forms, log output)
+
+## Scenarios
+
+### Tab switching
+
+**Given** the custom tool window is open
+**When** the user clicks the "Maker" tab
+**Then** the Maker tab content is displayed and the Finder tab content is hidden
+**And** the "Maker" tab label is visually highlighted
+
+### Finder — search flow
+
+**Given** the Finder tab is active
+**When** the user selects "User" from the dropdown and clicks "Find"
+**Then** a list of sample User results appears below
+
+### Maker — initial state
+
+**Given** the Maker tab is active
+**Then** the select and button are visible at the top
+**And** placeholder content area is shown below (for future expansion)
+
+### Default tab
+
+**Given** the custom tool opens for the first time
+**Then** the Finder tab is active by default
+
+## Out of Scope
+
+- Actual data fetching or real search functionality
+- Maker data entry forms (future spec)
+- Logging/activity feed in Maker tab (future spec)
+- Tab close/add/reorder functionality
+- Lazy loading of tab content

--- a/specs/014-tab-component-custom-tool/state.json
+++ b/specs/014-tab-component-custom-tool/state.json
@@ -1,0 +1,1 @@
+{ "step": "implement", "task": null, "substep": "code-review", "next": null, "updated": "2026-04-10" }

--- a/specs/014-tab-component-custom-tool/tasks.md
+++ b/specs/014-tab-component-custom-tool/tasks.md
@@ -1,0 +1,75 @@
+# Tasks: Tab Component & Custom Tool Demo
+
+**Spec**: 014-tab-component-custom-tool | **Date**: 2026-04-10
+
+---
+
+## Phase 1 — Core Implementation
+
+### T001: Create `ToolbarTabComponent` ✅
+
+Create `libs/ngx-dev-toolbar/src/components/tabs/tab.component.ts` — minimal standalone component with `label` input (string), `isActive` signal (set by parent), and `<ng-content>` wrapped in `@if (isActive())`. OnPush, signal-based.
+
+**Acceptance**: Component compiles, accepts `label` input, conditionally renders projected content based on `isActive`.
+
+---
+
+### T002: Create `ToolbarTabsComponent` with styling ✅
+
+Create `libs/ngx-dev-toolbar/src/components/tabs/tabs.component.ts` and `tabs.component.scss`.
+
+- Use `contentChildren(ToolbarTabComponent)` to discover tab children
+- Maintain `activeIndex = signal(0)` for active tab tracking
+- Render tab bar from children's labels with `role="tablist"` / `role="tab"` / `role="tabpanel"` ARIA attributes
+- Arrow key navigation between tabs, Enter/Space to activate
+- Active tab highlighted with bottom border using `--ndt-text-primary`
+- Defensive CSS: explicit `gap`, `padding`, `border: none`, `background: transparent` on tab buttons, `padding-top` on panel
+
+**Acceptance**: Tabs render, clicking/keyboard switches active tab, only active tab content is visible, ARIA roles present.
+
+---
+
+### T003: Export tab components from public API ✅
+
+Modify `libs/ngx-dev-toolbar/src/index.ts` — export `ToolbarTabsComponent` and `ToolbarTabComponent`.
+
+**Acceptance**: Both components importable via `ngx-dev-toolbar` package.
+
+---
+
+### T004: Create custom tool demo component ✅
+
+Create `apps/ngx-dev-toolbar-demo/src/app/components/custom-tool-demo/custom-tool-demo.component.ts` and `.scss`.
+
+- Wrap in `ToolbarToolComponent` with icon and title
+- **Finder tab**: `ndt-select` (entity types: User, Order, Product) + `ndt-button` "Find" in a row. Below, `ndt-list-item` entries populated from mock data on button click.
+- **Maker tab**: `ndt-select` (entity types) + `ndt-button` "Create" in a row. Placeholder content below.
+- Mock data as simple arrays in the component file
+
+**Acceptance**: Custom tool renders in toolbar, both tabs functional, Finder shows mock results on "Find" click.
+
+---
+
+### T005: Register custom tool demo in demo app ✅
+
+Modify `apps/ngx-dev-toolbar-demo/src/app/app.component.ts` — import and render the custom tool demo component.
+
+**Acceptance**: Demo app shows the custom tool in the toolbar, tabs work end-to-end.
+
+---
+
+## Phase 2 — Quality
+
+### T006: Unit tests for tab components — `test-expert` [P][A] ✅
+
+Add tests for `ToolbarTabsComponent` and `ToolbarTabComponent`:
+
+- Tab switching updates active content
+- Default first tab is active
+- Keyboard navigation (arrow keys, Enter/Space)
+- ARIA attributes set correctly
+- Only active tab content is rendered
+
+**Acceptance**: All tests pass via `nx test ngx-dev-toolbar`.
+
+---


### PR DESCRIPTION
## Summary
- Add `customTools` option to `provideToolbar()` config for registering app-specific tool components
- Add reusable `ndt-tabs`/`ndt-tab` components to the library
- Move demo custom tool from library to demo app (no longer ships in the package)
- Fix select overlay min-width to match trigger
- Add list-item padding fix

## Test plan
- [x] `nx test ngx-dev-toolbar` — 373 tests pass (18 suites)
- [x] `nx build ngx-dev-toolbar` — library builds cleanly
- [ ] `nx serve ngx-dev-toolbar-demo` — custom tool icon appears in toolbar, Finder/Maker tabs work