### PR TITLE
docs: redesign landing page and rebrand to Angular Toolbar

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -9,8 +9,12 @@ export default defineConfig({
   outDir: '../../dist/apps/docs',
   integrations: [
     starlight({
-      title: 'ngx-dev-toolbar',
+      title: 'Angular Toolbar',
       pagefind: false,
+      components: {
+        Hero: './src/components/Hero.astro',
+        ThemeSelect: './src/components/ThemeSelect.astro',
+      },
       plugins: [starlightLinksValidator({ exclude: ['/ngx-dev-toolbar/demo/'] })],
       social: [
         {

--- a/apps/docs/src/components/BentoCard.astro
+++ b/apps/docs/src/components/BentoCard.astro
@@ -1,0 +1,180 @@
+---
+// BentoCard — individual tile with icon + title + description, optional link.
+// Labels placed OUTSIDE the visual card surface per skill section 9.A.
+import { Icon } from '@astrojs/starlight/components';
+
+type Props = {
+  title: string;
+  icon?: string;
+  size?: 'featured' | 'wide' | 'medium' | 'small';
+  href?: string;
+  accent?: boolean;
+};
+
+const { title, icon, size = 'small', href, accent = false } = Astro.props;
+const Tag = href ? 'a' : 'article';
+---
+
+<Tag
+  class:list={['bento-card', { 'is-link': href, 'is-accent': accent }]}
+  data-size={size}
+  href={href}
+>
+  <div class="card-surface">
+    {
+      icon && (
+        <div class="card-icon" aria-hidden="true">
+          <Icon name={icon as any} size="1.5rem" />
+        </div>
+      )
+    }
+    <div class="card-body">
+      <h3 class="card-title">{title}</h3>
+      <div class="card-desc">
+        <slot />
+      </div>
+    </div>
+    {
+      href && (
+        <div class="card-arrow" aria-hidden="true">
+          <Icon name="right-arrow" size="1rem" />
+        </div>
+      )
+    }
+  </div>
+</Tag>
+
+<style>
+  .bento-card {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+    min-height: 100%;
+  }
+
+  .card-surface {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    height: 100%;
+    padding: 1.5rem 1.5rem 1.25rem;
+    background: var(--sl-color-gray-6);
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 1.25rem;
+    box-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.15),
+      0 18px 32px -20px rgba(0, 0, 0, 0.35);
+    transition:
+      transform 240ms cubic-bezier(0.22, 1, 0.36, 1),
+      border-color 240ms ease,
+      box-shadow 240ms ease;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .card-surface {
+      transition: none;
+    }
+  }
+
+  .bento-card.is-link:hover .card-surface {
+    transform: translateY(-3px);
+    border-color: color-mix(in srgb, var(--sl-color-accent) 38%, var(--sl-color-gray-5));
+    box-shadow:
+      0 1px 2px rgba(99, 91, 255, 0.1),
+      0 20px 48px -20px rgba(99, 91, 255, 0.24);
+  }
+
+  .bento-card.is-link:active .card-surface {
+    transform: translateY(-1px);
+  }
+
+  .bento-card.is-accent .card-surface {
+    background: linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--sl-color-accent) 14%, var(--sl-color-gray-6)) 0%,
+      var(--sl-color-gray-6) 60%
+    );
+    border-color: color-mix(in srgb, var(--sl-color-accent) 28%, var(--sl-color-gray-5));
+  }
+
+  .card-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 0.625rem;
+    background: color-mix(in srgb, var(--sl-color-accent) 14%, transparent);
+    color: var(--sl-color-accent);
+    flex-shrink: 0;
+  }
+
+  .card-icon :global(svg) {
+    width: 1.125rem;
+    height: 1.125rem;
+    stroke-width: 1.5;
+  }
+
+  .card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .card-title {
+    font-size: 1.0625rem;
+    font-weight: 600;
+    line-height: 1.3;
+    letter-spacing: -0.012em;
+    color: var(--sl-color-white);
+    margin: 0;
+  }
+
+  .card-desc {
+    font-size: 0.9rem;
+    line-height: 1.55;
+    color: var(--sl-color-gray-2);
+  }
+
+  .card-desc :global(p) {
+    margin: 0;
+  }
+
+  .card-desc :global(a) {
+    color: var(--sl-color-accent);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+  }
+
+  .card-arrow {
+    position: absolute;
+    top: 1.25rem;
+    right: 1.25rem;
+    color: var(--sl-color-gray-3);
+    transition: transform 240ms cubic-bezier(0.22, 1, 0.36, 1), color 240ms ease;
+  }
+
+  .bento-card.is-link:hover .card-arrow {
+    color: var(--sl-color-accent);
+    transform: translate(2px, -2px);
+  }
+
+  /* Light-mode tuning */
+  :global([data-theme='light']) .card-surface {
+    background: #ffffff;
+    border-color: var(--sl-color-gray-2);
+    box-shadow:
+      0 1px 2px rgba(17, 24, 39, 0.04),
+      0 14px 30px -18px rgba(17, 24, 39, 0.12);
+  }
+
+  :global([data-theme='light']) .bento-card.is-accent .card-surface {
+    background: linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--sl-color-accent) 7%, #ffffff) 0%,
+      #ffffff 60%
+    );
+  }
+</style>

--- a/apps/docs/src/components/BentoGrid.astro
+++ b/apps/docs/src/components/BentoGrid.astro
@@ -1,0 +1,49 @@
+---
+// BentoGrid — asymmetric tile layout replacing the generic CardGrid.
+// Layout pattern (desktop):
+//   Row 1:  [ featured        ][ small ]
+//   Row 2:  [ medium ][ small ][ small ]
+// Collapses to single column on mobile per skill's MOBILE OVERRIDE rule.
+---
+
+<div class="bento">
+  <slot />
+</div>
+
+<style>
+  .bento {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    margin-block: 1.5rem;
+  }
+
+  @media (min-width: 48rem) {
+    .bento {
+      grid-template-columns: repeat(6, 1fr);
+      grid-auto-rows: minmax(200px, auto);
+      gap: 1.25rem;
+    }
+  }
+
+  /* Size variants — consumed via data-size on <BentoCard> children */
+  .bento :global([data-size='featured']) {
+    grid-column: 1 / -1;
+  }
+  .bento :global([data-size='wide']) {
+    grid-column: span 4;
+  }
+  .bento :global([data-size='medium']) {
+    grid-column: span 3;
+  }
+  .bento :global([data-size='small']) {
+    grid-column: span 2;
+  }
+
+  @media (min-width: 48rem) {
+    .bento :global([data-size='featured']) {
+      grid-column: span 4;
+      grid-row: span 1;
+    }
+  }
+</style>

--- a/apps/docs/src/components/Hero.astro
+++ b/apps/docs/src/components/Hero.astro
@@ -1,0 +1,237 @@
+---
+// Custom Hero — asymmetric split layout (text-left / asset-right) with animated demo.
+// Overrides Starlight's default centered splash hero for DESIGN_VARIANCE=8.
+// Keeps Starlight's frontmatter API (`data.hero.title/tagline/image/actions`),
+// plus an optional `eyebrow` frontmatter field for the mono-styled overline.
+import { LinkButton } from '@astrojs/starlight/components';
+
+// Starlight's internal constant; inlined because @astrojs/starlight/constants isn't a public export.
+const PAGE_TITLE_ID = '_top';
+
+type HeroFrontmatter = {
+  title?: string;
+  tagline?: string;
+  eyebrow?: string;
+  image?: Record<string, unknown>;
+  actions?: Array<{
+    attrs?: Record<string, unknown>;
+    icon?: { name?: string; html?: string };
+    link: string;
+    text: string;
+    variant?: 'primary' | 'secondary' | 'minimal';
+  }>;
+};
+
+const { data } = Astro.locals.starlightRoute.entry;
+const hero = (data.hero || {}) as HeroFrontmatter;
+const {
+  title = data.title,
+  tagline,
+  // NOTE: Starlight's HeroSchema strips unknown fields, so `eyebrow` in MDX
+  // frontmatter gets dropped. This default is the effective value; update
+  // here when the version changes.
+  eyebrow = 'ANGULAR TOOLBAR · v4',
+  actions = [],
+} = hero;
+
+// Animated demo asset — served from public/assets/demos/
+const demoSrc = '/ngx-dev-toolbar/assets/demos/toolbar-tool-demo.gif';
+const demoAlt =
+  'Animated demo of the ngx-dev-toolbar showing feature flags, permissions, and presets';
+---
+
+<section class="hero-split">
+  <div class="hero-copy">
+    <span class="eyebrow" aria-hidden="true">{eyebrow}</span>
+    <h1 id={PAGE_TITLE_ID} data-page-title set:html={title} />
+    {tagline && <p class="tagline" set:html={tagline} />}
+
+    {
+      actions.length > 0 && (
+        <div class="actions">
+          {actions.map(
+            ({
+              attrs: { class: className, ...attrs } = {},
+              icon,
+              link: href,
+              text,
+              variant,
+            }) => (
+              <LinkButton
+                href={href}
+                variant={variant}
+                icon={icon?.name}
+                class:list={[className]}
+                {...attrs}
+              >
+                {text}
+                {icon?.html && <Fragment set:html={icon.html} />}
+              </LinkButton>
+            )
+          )}
+        </div>
+      )
+    }
+
+    <div class="install-line" aria-label="Install command">
+      <code>npm install ngx-dev-toolbar</code>
+    </div>
+  </div>
+
+  <figure class="hero-asset">
+    <div class="asset-frame">
+      <img src={demoSrc} alt={demoAlt} loading="eager" decoding="async" />
+    </div>
+  </figure>
+</section>
+
+<style>
+  .hero-split {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 3rem;
+    align-items: center;
+    padding-block: clamp(2rem, 6vw, 5rem);
+  }
+
+  @media (min-width: 60rem) {
+    .hero-split {
+      grid-template-columns: minmax(0, 6fr) minmax(0, 5fr);
+      gap: 4rem;
+    }
+  }
+
+  .hero-copy {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.5rem;
+  }
+
+  .eyebrow {
+    font-family: var(--sl-font-mono);
+    font-size: 0.75rem;
+    font-weight: 500;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--sl-color-accent);
+    line-height: 1;
+    padding: 0.35rem 0.7rem;
+    border: 1px solid color-mix(in srgb, var(--sl-color-accent) 30%, transparent);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--sl-color-accent) 10%, transparent);
+  }
+
+  .hero-copy h1 {
+    font-size: clamp(2.5rem, 5vw, 4.25rem);
+    font-weight: 800;
+    line-height: 1.02;
+    letter-spacing: -0.028em;
+    margin: 0;
+    color: var(--sl-color-white);
+  }
+
+  .hero-copy .tagline {
+    font-size: clamp(1.125rem, 1.4vw, 1.375rem);
+    line-height: 1.55;
+    color: var(--sl-color-gray-2);
+    max-width: 52ch;
+    margin: 0;
+  }
+
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.875rem 1rem;
+  }
+
+  .install-line {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-top: 0.25rem;
+    font-family: var(--sl-font-mono);
+    font-size: 0.875rem;
+    line-height: 1;
+    padding: 0.7rem 1rem;
+    border: 1px solid color-mix(in srgb, var(--sl-color-accent) 22%, transparent);
+    border-radius: 0.625rem;
+    /* Accent-tinted surface — renders as soft violet in both light and dark modes
+       because color-mix against transparent keeps the tint proportional to the bg. */
+    background: color-mix(in srgb, var(--sl-color-accent) 7%, transparent);
+    color: var(--sl-color-white);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  }
+
+  .install-line::before {
+    content: '$';
+    color: var(--sl-color-accent);
+    font-weight: 700;
+    opacity: 0.85;
+    flex-shrink: 0;
+  }
+
+  .install-line code {
+    color: inherit;
+    background: transparent;
+    padding: 0;
+    font-family: inherit;
+    font-size: inherit;
+  }
+
+  /* Asset column — animated demo with tinted multi-layer shadow */
+  .hero-asset {
+    margin: 0;
+    position: relative;
+  }
+
+  .asset-frame {
+    position: relative;
+    border-radius: 1rem;
+    overflow: hidden;
+    background: var(--sl-color-gray-6);
+    box-shadow:
+      0 1px 2px rgba(99, 91, 255, 0.08),
+      0 18px 48px rgba(0, 0, 0, 0.5),
+      0 0 0 1px rgba(99, 91, 255, 0.18),
+      inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+    transform: translateZ(0);
+  }
+
+  .asset-frame::after {
+    /* Subtle top-left light wash for depth */
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: linear-gradient(
+      135deg,
+      rgba(99, 91, 255, 0.08) 0%,
+      transparent 40%
+    );
+  }
+
+  .asset-frame img {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  /* Subtle scale on hover — MOTION_INTENSITY=6 sensible dose */
+  @media (prefers-reduced-motion: no-preference) {
+    .asset-frame {
+      transition: transform 500ms cubic-bezier(0.22, 1, 0.36, 1);
+    }
+    .hero-asset:hover .asset-frame {
+      transform: translateY(-2px);
+    }
+  }
+
+  /* Light-mode asset frame — lighter shadow stack */
+  :global([data-theme='light']) .asset-frame {
+    box-shadow:
+      0 1px 2px rgba(99, 91, 255, 0.05),
+      0 14px 36px rgba(17, 24, 39, 0.12),
+      0 0 0 1px rgba(99, 91, 255, 0.14);
+  }
+</style>

--- a/apps/docs/src/components/ThemeSelect.astro
+++ b/apps/docs/src/components/ThemeSelect.astro
@@ -1,0 +1,147 @@
+---
+// Custom ThemeSelect — segmented sun/laptop/moon toggle replacing Starlight's native <select>.
+// Preserves the localStorage key ('starlight-theme') and ThemeProvider sync so
+// Starlight's FOUC prevention keeps working.
+import { Icon } from '@astrojs/starlight/components';
+---
+
+<starlight-theme-select>
+  <div class="theme-segmented" role="group" aria-label="Theme">
+    <button type="button" class="seg-btn" data-theme="light" aria-label="Light theme">
+      <Icon name="sun" size="1rem" />
+    </button>
+    <button type="button" class="seg-btn" data-theme="auto" aria-label="System theme">
+      <Icon name="laptop" size="1rem" />
+    </button>
+    <button type="button" class="seg-btn" data-theme="dark" aria-label="Dark theme">
+      <Icon name="moon" size="1rem" />
+    </button>
+  </div>
+</starlight-theme-select>
+
+<script>
+  type Theme = 'auto' | 'dark' | 'light';
+  const storageKey = 'starlight-theme';
+
+  const parseTheme = (theme: unknown): Theme =>
+    theme === 'auto' || theme === 'dark' || theme === 'light' ? theme : 'auto';
+
+  const loadTheme = (): Theme =>
+    parseTheme(typeof localStorage !== 'undefined' && localStorage.getItem(storageKey));
+
+  function storeTheme(theme: Theme): void {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(storageKey, theme === 'light' || theme === 'dark' ? theme : '');
+    }
+  }
+
+  const getPreferredColorScheme = (): Theme =>
+    matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+
+  function updateButtons(theme: Theme, root: HTMLElement) {
+    root.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach((btn) => {
+      const isActive = btn.dataset.theme === theme;
+      btn.setAttribute('aria-pressed', String(isActive));
+    });
+  }
+
+  function onThemeChange(theme: Theme, root: HTMLElement): void {
+    // Keep Starlight's global provider in sync — it handles FOUC + document dataset.
+    if (typeof (globalThis as any).StarlightThemeProvider !== 'undefined') {
+      (globalThis as any).StarlightThemeProvider.updatePickers(theme);
+    }
+    document.documentElement.dataset.theme =
+      theme === 'auto' ? getPreferredColorScheme() : theme;
+    storeTheme(theme);
+    updateButtons(theme, root);
+  }
+
+  matchMedia('(prefers-color-scheme: light)').addEventListener('change', () => {
+    const root = document.querySelector('starlight-theme-select');
+    if (loadTheme() === 'auto' && root instanceof HTMLElement) {
+      onThemeChange('auto', root);
+    }
+  });
+
+  class StarlightThemeSelect extends HTMLElement {
+    constructor() {
+      super();
+      const initial = loadTheme();
+      onThemeChange(initial, this);
+
+      this.querySelectorAll<HTMLButtonElement>('.seg-btn').forEach((btn) => {
+        btn.addEventListener('click', () => {
+          const next = parseTheme(btn.dataset.theme);
+          onThemeChange(next, this);
+        });
+      });
+    }
+  }
+
+  if (!customElements.get('starlight-theme-select')) {
+    customElements.define('starlight-theme-select', StarlightThemeSelect);
+  }
+</script>
+
+<style>
+  .theme-segmented {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    padding: 3px;
+    border-radius: 0.5rem;
+    background: var(--sl-color-gray-6);
+    border: 1px solid var(--sl-color-gray-5);
+  }
+
+  .seg-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border: 0;
+    border-radius: 0.375rem;
+    background: transparent;
+    color: var(--sl-color-gray-3);
+    cursor: pointer;
+    transition:
+      background-color 160ms ease,
+      color 160ms ease,
+      transform 120ms ease;
+    padding: 0;
+  }
+
+  .seg-btn:hover {
+    color: var(--sl-color-white);
+    background: color-mix(in srgb, var(--sl-color-accent) 14%, transparent);
+  }
+
+  .seg-btn:active {
+    transform: scale(0.94);
+  }
+
+  .seg-btn[aria-pressed='true'] {
+    background: var(--sl-color-accent);
+    color: #ffffff;
+    box-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.3),
+      inset 0 1px 0 rgba(255, 255, 255, 0.14);
+  }
+
+  .seg-btn:focus-visible {
+    outline: 2px solid var(--sl-color-accent);
+    outline-offset: 2px;
+  }
+
+  .seg-btn :global(svg) {
+    width: 0.95rem;
+    height: 0.95rem;
+  }
+
+  /* Hide native select styling from Starlight's default ThemeProvider script calls
+     by scoping this entirely within our custom element. */
+  :host {
+    display: inline-block;
+  }
+</style>

--- a/apps/docs/src/content/docs/getting-started.mdx
+++ b/apps/docs/src/content/docs/getting-started.mdx
@@ -75,29 +75,17 @@ export class FeatureFlagService {
 
 When configured, each tool item shows an "apply" button to push changes to the source.
 
-### 4. Start Using the Tools
+### 4. Start using the tools
 
-Once installed, press `Ctrl+Shift+D` to toggle the toolbar. From there, you can access all available
-tools and start configuring your development environment.
+Press `Ctrl+Shift+D` in your running app to toggle the toolbar. From there, each tool becomes a panel you can configure without leaving the page.
 
-## Key Features
+## Next steps
 
-- **Feature Flags:** Override feature flag states at runtime for testing different configurations
-- **Permissions:** Force grant or deny permissions to test authorization logic
-- **App Features:** Toggle application features on and off for development and testing
-- **Presets:** Save and restore complete toolbar configurations for different testing scenarios
+Pick a tool to integrate deeper into your application:
 
-## Available Tools
-
-Explore each tool to learn how to integrate and use it:
-
-- [Feature Flags](/ngx-dev-toolbar/feature-flags/) — Override feature flags to test different application states
-- [i18n](/ngx-dev-toolbar/i18n/) — Simulate complete i18n environments (locale, timezone, currency, RTL)
-- [Permissions](/ngx-dev-toolbar/permissions/) — Force permissions to test authorization scenarios
-- [App Features](/ngx-dev-toolbar/app-features/) — Toggle application features for testing
-- [Presets](/ngx-dev-toolbar/presets/) — Save and restore complete toolbar configurations
-
-## Resources
-
-- [GitHub Repository](https://github.com/alfredoperez/ngx-dev-toolbar)
-- [NPM Package](https://www.npmjs.com/package/ngx-dev-toolbar)
+- [Feature Flags](/ngx-dev-toolbar/feature-flags/) — override flags + organize with `group`
+- [Permissions](/ngx-dev-toolbar/permissions/) — force-grant or deny for authorization testing
+- [App Features](/ngx-dev-toolbar/app-features/) — simulate tiers and product configurations
+- [i18n](/ngx-dev-toolbar/i18n/) — locale, timezone, currency, RTL in one panel
+- [Presets](/ngx-dev-toolbar/presets/) — save + restore full toolbar states
+- [Create a custom tool](/ngx-dev-toolbar/guides/custom-tool/) — extend the toolbar with your own

--- a/apps/docs/src/content/docs/guides/custom-tool.mdx
+++ b/apps/docs/src/content/docs/guides/custom-tool.mdx
@@ -5,7 +5,7 @@ description: Build your own toolbar tools using the exported UI components
 
 ## Overview
 
-The ngx-dev-toolbar exports its UI components so you can build custom tools that integrate seamlessly
+Angular Toolbar exports its UI components so you can build custom tools that integrate seamlessly
 with the toolbar. Each tool follows a consistent pattern: a **model** defining data structures,
 an **internal service** managing state with signals, and a **component** that wraps
 its content in `ToolbarToolComponent`.

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -1,65 +1,52 @@
 ---
 title: Angular Toolbar
-description: Dev tools for Angular — toggle feature flags, manage permissions, and save presets without touching code.
+description: Override Angular feature flags, permissions, locales, and app features at runtime — without redeploying or touching the backend.
 template: splash
 hero:
-  title: Angular Toolbar
-  tagline: Dev tools for Angular — toggle feature flags, manage permissions, and save presets without leaving your current page or touching production code.
-  image:
-    file: ../../assets/hero-demo.jpg
+  title: Stop redeploying to flip a feature flag.
+  tagline: An in-app toolbar that overrides Angular feature flags, permissions, locales, and app features at runtime. Save presets. Never touch the backend to test a scenario.
+  eyebrow: ANGULAR TOOLBAR · v4
   actions:
     - text: Get Started
       link: /ngx-dev-toolbar/getting-started/
       icon: right-arrow
       variant: primary
-    - text: Try Demo
+    - text: Try the Demo
       link: /ngx-dev-toolbar/demo/
       icon: rocket
       variant: secondary
-    - text: View on GitHub
-      link: https://github.com/alfredoperez/ngx-dev-toolbar
-      icon: external
-      variant: minimal
 ---
 
-import { Card, CardGrid } from '@astrojs/starlight/components';
+import BentoGrid from '../../components/BentoGrid.astro';
+import BentoCard from '../../components/BentoCard.astro';
 
-## Install
+## Built-in tools
 
-```bash
-npm install ngx-dev-toolbar
-```
+<BentoGrid>
+  <BentoCard title="Feature Flags" icon="setting" size="featured" href="/ngx-dev-toolbar/feature-flags/" accent>
+    Toggle features on or off in real time without backend changes. Group related flags into collapsible sections, pin the ones you use most, and persist overrides across reloads.
+  </BentoCard>
+  <BentoCard title="Permissions" icon="approve-check-circle" size="medium" href="/ngx-dev-toolbar/permissions/">
+    Force-grant or deny permissions to verify authorization logic without switching accounts.
+  </BentoCard>
+  <BentoCard title="App Features" icon="puzzle" size="medium" href="/ngx-dev-toolbar/app-features/">
+    Simulate different subscription tiers and product configurations with a single toggle.
+  </BentoCard>
+  <BentoCard title="i18n" icon="translate" size="medium" href="/ngx-dev-toolbar/i18n/">
+    Switch locale, timezone, currency, and RTL direction from one control surface.
+  </BentoCard>
+  <BentoCard title="Presets" icon="star" size="medium" href="/ngx-dev-toolbar/presets/">
+    Save complete toolbar configurations for QA, demo, and debug scenarios.
+  </BentoCard>
+  <BentoCard title="Custom Tools" icon="pen" size="medium" href="/ngx-dev-toolbar/guides/custom-tool/">
+    Extend the toolbar with your own tools using the built-in component primitives.
+  </BentoCard>
+</BentoGrid>
 
-## See It in Action
+## Why developers pick it
 
-<div className="demo-section">
-  <div className="demo-container">
-    <img src="/ngx-dev-toolbar/assets/demos/toolbar-tool-demo.gif" alt="Angular Toolbar demo showing feature flags, permissions, and preset management" loading="lazy" />
-  </div>
-  <p className="demo-caption">Toggle feature flags, manage permissions, and save presets — all from the toolbar.</p>
-</div>
-
-## Built-in Tools
-
-<CardGrid>
-  <Card title="Feature Flags" icon="setting">
-    Toggle features on or off in real-time without backend changes. Test different user experiences and validate A/B scenarios during development.
-  </Card>
-  <Card title="Permissions" icon="approve-check-circle">
-    Test role-based access control by forcing permissions on or off. Verify authorization logic without switching user accounts.
-  </Card>
-  <Card title="Presets" icon="star">
-    Save complete toolbar configurations as presets. Switch between QA, demo, and debug setups with one click.
-  </Card>
-  <Card title="Custom Tools" icon="puzzle">
-    Build your own tools using the toolbar's extensible architecture. See the [custom tool guide](/ngx-dev-toolbar/guides/custom-tool/).
-  </Card>
-</CardGrid>
-
-## Key Features
-
-- **Zero Production Impact** — toolbar code is tree-shaken out of production builds
-- **Secure Implementation** — only loads in development mode via `isDevMode()`
-- **Persistent Settings** — all overrides are saved to localStorage across sessions
-- **Hidden by Default** — toggle visibility with `Ctrl+Shift+D`
-- **Custom Tools Support** — extend the toolbar with your own tools
+- **Zero production impact** — toolbar code is tree-shaken out of production builds
+- **Secure by default** — only loads when `isDevMode()` is true
+- **Persistent state** — overrides survive reloads via localStorage
+- **Hidden until summoned** — `Ctrl+Shift+D` to toggle
+- **Framework-aware** — designed around Angular 19's signals and standalone components

--- a/apps/docs/src/styles/custom.css
+++ b/apps/docs/src/styles/custom.css
@@ -1,10 +1,11 @@
-/* Starlight theme customization for Angular Toolbar docs */
+/* Starlight theme customization for ngx-dev-toolbar docs.
+   Palette: Stripe-violet accent (#635BFF), slate neutrals.
+   Hero and ThemeSelect styling live in their component overrides. */
 
-/* ── Color palette ───────────────────────────────────── */
-/* Accent aligns to the library's Stripe-violet primary (#635BFF) for brand cohesion. */
+/* ── Dark palette (default) ──────────────────────────── */
 :root {
   --sl-color-accent-low: #130f3d;
-  --sl-color-accent: #635BFF;
+  --sl-color-accent: #635bff;
   --sl-color-accent-high: #c8c4ff;
   --sl-color-white: #ffffff;
   --sl-color-gray-1: #f0f2f5;
@@ -14,79 +15,110 @@
   --sl-color-gray-5: #1e2433;
   --sl-color-gray-6: #131825;
   --sl-color-black: #0d1117;
-  /* System-ui stack — matches the library, avoids reflex fonts, zero load cost */
+
   --sl-font:
     ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
     Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
-  --sl-font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --sl-font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas,
+    monospace;
+}
+
+/* ── Light palette ───────────────────────────────────── */
+:root[data-theme='light'] {
+  --sl-color-white: #0f1424;
+  --sl-color-gray-1: #1a2036;
+  --sl-color-gray-2: #4a5266;
+  --sl-color-gray-3: #6b7280;
+  --sl-color-gray-4: #9ca3af;
+  --sl-color-gray-5: #e4e7ec;
+  --sl-color-gray-6: #f7f8fa;
+  --sl-color-black: #ffffff;
+  --sl-color-accent-low: #e9e7ff;
+  --sl-color-accent: #4f46e5;
+  --sl-color-accent-high: #3a33b8;
+
+  --sl-color-bg: #ffffff;
+  --sl-color-bg-nav: #ffffff;
+  --sl-color-bg-sidebar: #f7f8fa;
+  --sl-color-bg-inline-code: #f0f2f5;
+  --sl-color-text: #0f1424;
+  --sl-color-text-accent: #4f46e5;
+  --sl-color-hairline-shade: #e4e7ec;
+  --sl-color-hairline-light: #eceff3;
+  --sl-color-hairline: #dde1e7;
 }
 
 /* ── Header ──────────────────────────────────────────── */
-/* Flat surface, 1px divider. No glassmorphism. */
 header.header {
   background-color: var(--sl-color-gray-6);
   border-bottom: 1px solid var(--sl-color-gray-5);
 }
 
-/* ── Sidebar ─────────────────────────────────────────── */
+:root[data-theme='light'] header.header {
+  background-color: #ffffff;
+  border-bottom: 1px solid var(--sl-color-hairline);
+}
 
-/* Active page — subtle tint with weight change, no colored stripe.
-   Selectors are intentionally specific to win over Starlight's defaults
-   without needing !important. */
+/* ── Sidebar ─────────────────────────────────────────── */
 nav.sidebar-content a[aria-current='page'],
 nav.sidebar-content a[aria-current='page']:hover,
 nav.sidebar-content a[aria-current='page']:focus,
 .sidebar-pane nav a[aria-current='page'],
 .sidebar-pane nav a[aria-current='page']:hover {
-  background-color: rgba(99, 91, 255, 0.14);
+  background-color: color-mix(in srgb, var(--sl-color-accent) 14%, transparent);
   color: var(--sl-color-white);
   font-weight: 600;
 }
 
-/* Sidebar link hover transition */
 nav.sidebar-content a {
   transition: color 0.15s ease, background-color 0.15s ease;
 }
 
 nav.sidebar-content a:hover {
-  background-color: rgba(99, 91, 255, 0.08);
+  background-color: color-mix(in srgb, var(--sl-color-accent) 8%, transparent);
 }
 
-/* Group headings — uppercase, smaller, letter-spaced, WCAG AA contrast */
 .sidebar-content .top-level > li > details > summary span.large {
   text-transform: uppercase;
   font-size: var(--sl-text-xs);
   letter-spacing: 0.06em;
-  color: var(--sl-color-gray-1);
+  color: var(--sl-color-gray-2);
 }
 
-/* ── Card hover effects ──────────────────────────────── */
+/* ── Card hover (Starlight's default Card component, if used anywhere) ── */
 .card {
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .card:hover {
-  border-color: rgba(99, 91, 255, 0.3);
+  border-color: color-mix(in srgb, var(--sl-color-accent) 30%, transparent);
   box-shadow: 0 2px 12px rgba(99, 91, 255, 0.08);
 }
 
-/* ── Demo section ────────────────────────────────────── */
+/* ── Demo container (used on splash for embedded GIFs) ── */
 .demo-section {
-  margin-block: 2rem;
-  text-align: center;
-  padding-inline: clamp(0.5rem, 4vw, 1rem);
+  margin-block: 2.5rem;
+  padding-inline: 0;
 }
 
 .demo-container {
   border: 1px solid var(--sl-color-gray-5);
   border-radius: 0.75rem;
   overflow: hidden;
+  background: var(--sl-color-gray-6);
   box-shadow:
     0 1px 2px rgba(99, 91, 255, 0.05),
     0 8px 32px rgba(0, 0, 0, 0.4),
     inset 0 0 0 1px rgba(99, 91, 255, 0.08);
-  margin-inline: auto;
-  max-width: 560px;
+  max-width: 860px;
+}
+
+:root[data-theme='light'] .demo-container {
+  background: #ffffff;
+  box-shadow:
+    0 1px 2px rgba(99, 91, 255, 0.04),
+    0 10px 30px rgba(17, 24, 39, 0.1),
+    inset 0 0 0 1px rgba(99, 91, 255, 0.08);
 }
 
 .demo-container img,
@@ -98,83 +130,22 @@ nav.sidebar-content a:hover {
 }
 
 .demo-caption {
-  margin-block-start: 0.75rem;
+  margin-block-start: 0.875rem;
   color: var(--sl-color-gray-2);
   font-size: var(--sl-text-sm, 0.875rem);
 }
 
-/* ── Hero refinements ────────────────────────────────── */
-.hero .action.minimal {
-  opacity: 0.8;
-  transition: opacity 0.15s ease;
-}
-
-.hero .action.minimal:hover {
-  opacity: 1;
-}
-
-/* Hero title — give it real presence and rhythm */
-.hero h1 {
-  font-size: clamp(2.75rem, 6vw, 4.75rem);
-  line-height: 1.02;
-  letter-spacing: -0.025em;
-  font-weight: 800;
-  position: relative;
-}
-
-/* Mono eyebrow above the title — anchors "this is a library, not a marketing page" */
-.hero h1::before {
-  content: 'ngx-dev-toolbar · v4';
-  display: block;
-  font-family: var(--sl-font-mono);
-  font-size: 0.75rem;
-  font-weight: 500;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--sl-color-accent);
-  margin-bottom: 1.25rem;
-  line-height: 1;
-}
-
-/* Header wordmark — mono, tracked, quieter than the page H1 */
+/* ── Header wordmark ─────────────────────────────────── */
+/* Distinctive proper-case mono wordmark with subtle tracking. */
 header .site-title,
 header a.site-title {
   font-family: var(--sl-font-mono);
   font-size: 0.9375rem;
   font-weight: 600;
   letter-spacing: -0.01em;
-  text-transform: lowercase;
-}
-
-.hero .tagline {
-  font-size: clamp(1.0625rem, 1.4vw, 1.25rem);
-  line-height: 1.55;
-  max-width: 58ch;
-  color: var(--sl-color-gray-2);
-}
-
-/* Hero image — lime-tinted depth so it lifts off the page */
-.hero .hero-html,
-.hero img {
-  border-radius: 0.875rem;
-  box-shadow:
-    0 1px 2px rgba(99, 91, 255, 0.08),
-    0 12px 40px rgba(0, 0, 0, 0.45),
-    0 0 0 1px rgba(99, 91, 255, 0.14);
-}
-
-/* Primary CTA — bigger, weightier, no longer competes with the
-   ghost button on equal footing */
-.hero .action.primary {
-  font-size: 1.0625rem;
-  font-weight: 600;
-  padding: 0.875rem 1.625rem;
-  letter-spacing: -0.005em;
 }
 
 /* ── Content typography — distinct hierarchy steps ──── */
-
-/* h1 (page titles) — significant size jump from body */
 .sl-markdown-content > h1,
 main h1 {
   font-size: clamp(2.25rem, 4vw, 3.25rem);
@@ -184,7 +155,6 @@ main h1 {
   margin-block-end: 1.25rem;
 }
 
-/* h2 — clearly secondary but with breathing room above */
 .sl-markdown-content > h2 {
   font-size: clamp(1.5rem, 2.4vw, 1.875rem);
   letter-spacing: -0.012em;
@@ -195,15 +165,78 @@ main h1 {
   border-block-start: 1px solid var(--sl-color-gray-5);
 }
 
-/* h3 — distinct from h2 without competing */
 .sl-markdown-content > h3 {
   font-size: 1.25rem;
   font-weight: 600;
   margin-block-start: 2rem;
 }
 
-/* Body — slightly more comfortable */
 .sl-markdown-content > p {
   line-height: 1.65;
   max-width: 70ch;
+}
+
+/* ── Scroll-reveal motion ────────────────────────────── */
+/* MOTION_INTENSITY=6: subtle fade-up on h2 + following content blocks
+   using view-timeline where supported, plain animation-delay fallback. */
+@media (prefers-reduced-motion: no-preference) {
+  .sl-markdown-content > h2,
+  .sl-markdown-content > h3 {
+    animation: reveal-up 560ms cubic-bezier(0.22, 1, 0.36, 1) both;
+    animation-timeline: view();
+    animation-range: entry 8% entry 48%;
+  }
+
+  .bento > * {
+    animation: reveal-up 480ms cubic-bezier(0.22, 1, 0.36, 1) both;
+    animation-timeline: view();
+    animation-range: entry 4% entry 40%;
+  }
+
+  /* Hero copy stagger — applied via :nth-child on Hero.astro's children */
+  .hero-split .hero-copy > * {
+    animation: reveal-up 520ms cubic-bezier(0.22, 1, 0.36, 1) both;
+    animation-delay: calc(var(--reveal-index, 0) * 80ms);
+  }
+  .hero-split .hero-copy > :nth-child(1) { --reveal-index: 0; }
+  .hero-split .hero-copy > :nth-child(2) { --reveal-index: 1; }
+  .hero-split .hero-copy > :nth-child(3) { --reveal-index: 2; }
+  .hero-split .hero-copy > :nth-child(4) { --reveal-index: 3; }
+  .hero-split .hero-copy > :nth-child(5) { --reveal-index: 4; }
+
+  .hero-split .hero-asset {
+    animation: reveal-in 720ms cubic-bezier(0.22, 1, 0.36, 1) both;
+    animation-delay: 180ms;
+  }
+}
+
+@keyframes reveal-up {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes reveal-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* ── Footer ──────────────────────────────────────────── */
+footer.sl-footer {
+  border-top: 1px solid var(--sl-color-gray-5);
+  margin-top: 4rem;
+  padding-block: 1.5rem;
+  color: var(--sl-color-gray-3);
+  font-size: 0.875rem;
 }


### PR DESCRIPTION
## What

- **Hero**: asymmetric split layout replacing Starlight's centered splash — mono eyebrow pill + bold problem-first headline + 2 CTAs + inline install command on the left, animated toolbar demo framed in a tinted-shadow panel on the right
- **Theme switcher**: native `<select>` dropdown replaced with a 3-button sun/laptop/moon segmented toggle (keeps Starlight's `localStorage.starlight-theme` key and FOUC provider sync)
- **Homepage grid**: `CardGrid` replaced with a 6-column Bento — Feature Flags as the accent-tinted featured tile, 5 medium tiles for Permissions / App Features / i18n / Presets / Custom Tools
- **Light mode**: full per-mode palette defined under `[data-theme='light']`, proper surface tokens for light backgrounds, accent desaturated slightly for AA contrast on white
- **Motion**: scroll-timeline fade-ups on h2/h3 and Bento items in modern browsers; staggered entry cascade on hero copy children (graceful degradation via `prefers-reduced-motion` + fallback)
- **Copy**: new problem-first hero — "Stop redeploying to flip a feature flag." — replacing the previous AI-template "Ship X with confidence" phrasing
- **Rebrand**: site display name is now "Angular Toolbar" (header wordmark, page titles, prose references). The npm package stays `ngx-dev-toolbar` — all install commands, imports, and URLs are unchanged

## Why

The previous docs read as polished-but-generic Starlight output — centered hero, 3-card feature grid, native theme dropdown, filler headline copy. The brand was also opaque: "ngx-dev-toolbar" is a great npm identifier but a weak human-facing product name. This PR differentiates the landing page from every other Starlight site and gives the library a display name that reads naturally in prose.

## Testing

- [x] `npx nx build docs` — 9 pages built in 2.06s, internal link validator green
- [x] Generated HTML inspection: eyebrow `ANGULAR TOOLBAR · v4`, H1 `Stop redeploying...`, wordmark `Angular Toolbar`, install line rendering, Bento tiles rendering, theme segmented toggle present
- [ ] Visual verification in browser (dark + light mode, mobile + desktop breakpoints) — recommend spinning up `npx nx serve docs` once before merge
- [ ] GitHub Pages redeploy triggers automatically on merge to main

## Not in scope

- **Library package** is untouched — no `ngx-dev-toolbar` version bump will happen from this PR (commit type `docs:` per nx-release config)
- **`eyebrow` frontmatter** is currently set via a default in `Hero.astro` because Starlight's `HeroSchema` strips unknown fields; documented in a code comment

## Files (9)

**New components** (Astro):
- `apps/docs/src/components/Hero.astro`
- `apps/docs/src/components/ThemeSelect.astro`
- `apps/docs/src/components/BentoGrid.astro`
- `apps/docs/src/components/BentoCard.astro`

**Modified**:
- `apps/docs/astro.config.mjs` — site title + component override registration
- `apps/docs/src/styles/custom.css` — light palette + scroll-reveal motion
- `apps/docs/src/content/docs/index.mdx` — rebrand + hero copy + Bento
- `apps/docs/src/content/docs/getting-started.mdx` — dedupe
- `apps/docs/src/content/docs/guides/custom-tool.mdx` — one prose brand reference