### PR TITLE
chore: add SDD workflow config

### DIFF
--- a/.sdd.json
+++ b/.sdd.json
@@ -1,0 +1,11 @@
+{
+  "branchStage": "implement",
+  "branchNameFormat": "{type}/{slug}",
+  "buildCommand": "nx affected -t build",
+  "testCommand": "nx affected -t test",
+  "hooks": {
+    "pre:commit": [
+      { "shell": "npm run code-check", "blocking": true }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.sdd.json` so the SDD plugin (v1.10.0+) creates the feature branch at the start of `/sdd:implement` using `feat/{slug}` / `fix/{slug}` naming (the `{type}` is inferred from the feature description).
- Wires `buildCommand` / `testCommand` to `nx affected -t build` / `nx affected -t test`.
- Adds a blocking `pre:commit` hook that runs `npm run code-check` (lint + test + build on affected projects).

Opt-in config — harmless if SDD isn't installed.

## Test plan
- [ ] Install SDD v1.10.0+ and run `/sdd:auto "add something"` — verify a `feat/...` branch is created at implement.
- [ ] Run `/sdd:implement` on a change that breaks lint — verify `pre:commit` halts before commit.