### PR TITLE
feat(toolbar): add All chip to tool filter groups

### DIFF
--- a/libs/ngx-dev-toolbar/src/components/tool-header/tool-header.component.ts
+++ b/libs/ngx-dev-toolbar/src/components/tool-header/tool-header.component.ts
@@ -71,25 +71,13 @@ export class ToolbarToolHeaderComponent {
   searchAriaLabel = input<string>('');
   filterOptions = input<ToolHeaderFilterOption[]>([]);
   filterAriaLabel = input<string>('Filter items');
-  /**
-   * Value to set when the user clicks an already-active filter chip
-   * (i.e., to "clear" the filter back to a default no-chip state).
-   * Defaults to 'all'.
-   */
-  defaultFilter = input<string>('all');
 
   protected clearSearch(): void {
     this.searchQuery.set('');
   }
 
   protected onFilterClick(value: string): void {
-    // Click an already-active chip to clear it back to the default
-    // (no chip visually selected when activeFilter === defaultFilter).
-    if (this.activeFilter() === value) {
-      this.activeFilter.set(this.defaultFilter());
-    } else {
-      this.activeFilter.set(value);
-    }
+    this.activeFilter.set(value);
   }
 
   protected onFilterKeydown(event: KeyboardEvent, value: string): void {

--- a/libs/ngx-dev-toolbar/src/tools/app-features-tool/app-features-tool.component.spec.ts
+++ b/libs/ngx-dev-toolbar/src/tools/app-features-tool/app-features-tool.component.spec.ts
@@ -1,7 +1,65 @@
+import { TestBed } from '@angular/core/testing';
+import { computed, signal } from '@angular/core';
 import { ToolbarAppFeaturesToolComponent } from './app-features-tool.component';
+import { ToolbarInternalAppFeaturesService } from './app-features-internal.service';
+import { ToolbarStorageService } from '../../utils/storage.service';
+import { ToolbarStateService } from '../../toolbar-state.service';
+import { ToolbarAppFeature } from './app-features.models';
 
 describe('ToolbarAppFeaturesToolComponent', () => {
   it('should be defined', () => {
     expect(ToolbarAppFeaturesToolComponent).toBeDefined();
+  });
+
+  describe('filter dropdown functionality', () => {
+    let component: ToolbarAppFeaturesToolComponent;
+
+    const mockFeatures: ToolbarAppFeature[] = [
+      { id: 'f1', name: 'F1', description: '', isEnabled: true, isForced: false },
+    ];
+
+    beforeEach(() => {
+      const mockInternalService = {
+        features: signal(mockFeatures),
+        hasApplyCallback: computed(() => false),
+        applyStates: signal({}),
+        setFeature: jest.fn(),
+        removeFeatureOverride: jest.fn(),
+        applyToSource: jest.fn(),
+      };
+
+      const mockStorageService = {
+        get: jest.fn().mockReturnValue(null),
+        set: jest.fn(),
+        remove: jest.fn(),
+      };
+
+      const mockStateService = {
+        theme: signal('light' as 'light' | 'dark'),
+        isEnabled: signal(true),
+        activeToolId: signal(null),
+        position: signal('bottom'),
+        isHidden: signal(false),
+        isToolbarVisible: signal(true),
+      };
+
+      TestBed.configureTestingModule({
+        imports: [ToolbarAppFeaturesToolComponent],
+        providers: [
+          { provide: ToolbarInternalAppFeaturesService, useValue: mockInternalService },
+          { provide: ToolbarStorageService, useValue: mockStorageService },
+          { provide: ToolbarStateService, useValue: mockStateService },
+        ],
+      });
+
+      component = TestBed.createComponent(ToolbarAppFeaturesToolComponent).componentInstance;
+    });
+
+    it('clicking the same filter value twice keeps the filter active (regression for the invisible-reset bug)', () => {
+      component.onFilterChange('forced');
+      component.onFilterChange('forced');
+
+      expect((component as any).activeFilter()).toBe('forced');
+    });
   });
 });

--- a/libs/ngx-dev-toolbar/src/tools/app-features-tool/app-features-tool.component.ts
+++ b/libs/ngx-dev-toolbar/src/tools/app-features-tool/app-features-tool.component.ts
@@ -286,6 +286,7 @@ export class ToolbarAppFeaturesToolComponent {
   } as ToolbarWindowOptions;
 
   protected readonly filterOptions = [
+    { value: 'all', label: 'All' },
     { value: 'forced', label: 'Forced' },
     { value: 'enabled', label: 'Enabled' },
     { value: 'disabled', label: 'Disabled' },

--- a/libs/ngx-dev-toolbar/src/tools/feature-flags-tool/feature-flags-tool.component.spec.ts
+++ b/libs/ngx-dev-toolbar/src/tools/feature-flags-tool/feature-flags-tool.component.spec.ts
@@ -103,6 +103,15 @@ describe('ToolbarFeatureFlagsToolComponent', () => {
       expect(result[2].id).toBe('beta');
     });
 
+    it('clicking the same filter value twice keeps the filter active (regression for the invisible-reset bug)', () => {
+      // Act
+      component.onFilterChange('forced');
+      component.onFilterChange('forced');
+
+      // Assert
+      expect((component as any).activeFilter()).toBe('forced');
+    });
+
     it('should load pinnedIds from saved ToolViewState', () => {
       // Arrange: set up storage mock to return saved state with pinned IDs
       mockStorageService.get.mockReturnValue({

--- a/libs/ngx-dev-toolbar/src/tools/feature-flags-tool/feature-flags-tool.component.ts
+++ b/libs/ngx-dev-toolbar/src/tools/feature-flags-tool/feature-flags-tool.component.ts
@@ -262,6 +262,7 @@ export class ToolbarFeatureFlagsToolComponent {
   } as ToolbarWindowOptions;
 
   protected readonly filterOptions = [
+    { value: 'all', label: 'All' },
     { value: 'forced', label: 'Forced' },
     { value: 'enabled', label: 'Enabled' },
     { value: 'disabled', label: 'Disabled' },

--- a/libs/ngx-dev-toolbar/src/tools/permissions-tool/permissions-tool.component.spec.ts
+++ b/libs/ngx-dev-toolbar/src/tools/permissions-tool/permissions-tool.component.spec.ts
@@ -139,10 +139,11 @@ describe('ToolbarPermissionsToolComponent', () => {
     });
 
     it('should have filter options configured', () => {
-      expect(component['filterOptions'].length).toBe(3);
-      expect(component['filterOptions'][0].value).toBe('forced');
-      expect(component['filterOptions'][1].value).toBe('granted');
-      expect(component['filterOptions'][2].value).toBe('denied');
+      expect(component['filterOptions'].length).toBe(4);
+      expect(component['filterOptions'][0].value).toBe('all');
+      expect(component['filterOptions'][1].value).toBe('forced');
+      expect(component['filterOptions'][2].value).toBe('granted');
+      expect(component['filterOptions'][3].value).toBe('denied');
     });
 
     it('should have permission value options configured', () => {
@@ -245,6 +246,13 @@ describe('ToolbarPermissionsToolComponent', () => {
       const filtered = component['filteredPermissions']();
       expect(filtered.length).toBe(1);
       expect(filtered[0].id).toBe('perm2');
+    });
+
+    it('clicking the same filter value twice keeps the filter active (regression for the invisible-reset bug)', () => {
+      component.onFilterChange('forced');
+      component.onFilterChange('forced');
+
+      expect(component['activeFilter']()).toBe('forced');
     });
   });
 

--- a/libs/ngx-dev-toolbar/src/tools/permissions-tool/permissions-tool.component.ts
+++ b/libs/ngx-dev-toolbar/src/tools/permissions-tool/permissions-tool.component.ts
@@ -287,6 +287,7 @@ export class ToolbarPermissionsToolComponent {
   } as ToolbarWindowOptions;
 
   protected readonly filterOptions = [
+    { value: 'all', label: 'All' },
     { value: 'forced', label: 'Forced' },
     { value: 'granted', label: 'Granted' },
     { value: 'denied', label: 'Denied' },

--- a/specs/019-add-all-filter/.spec-context.json
+++ b/specs/019-add-all-filter/.spec-context.json
@@ -1,9 +1,13 @@
 {
   "workflow": "sdd",
-  "currentStep": "implement",
+  "currentStep": "done",
   "currentTask": null,
-  "progress": "commit-review",
-  "next": "implement",
+  "progress": null,
+  "next": "done",
+  "status": "completed",
+  "checkpointStatus": { "commit": true, "pr": true },
+  "prUrl": "https://github.com/alfredoperez/ngx-dev-toolbar/pull/49",
+  "prNumber": 49,
   "updated": "2026-04-23",
   "selectedAt": "2026-04-23T12:25:04Z",
   "specName": "Add All Filter",
@@ -82,7 +86,7 @@
     { "task": "T002", "note": "New regression test placed in 'component logic' describe block (no filter-focused describe exists). Low-risk organizational choice." },
     { "task": "T003", "note": "Subagent wrote invalid `new Component()` test; main thread rewrote with TestBed before phase close. Test file pre-existed as stub, so this is a net improvement in coverage." }
   ],
-  "last_action": "CP1 approved; at CP3 commit review",
+  "last_action": "PR #49 opened — feat(toolbar): add All chip to tool filter groups",
   "transitions": [
     { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-23T12:25:04Z" },
     { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-23T12:25:05Z" },
@@ -99,6 +103,7 @@
     { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-23T12:30:00Z" },
     { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-23T12:32:00Z" },
     { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-23T12:34:00Z" },
-    { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-23T12:36:00Z" }
+    { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-23T12:36:00Z" },
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-23T12:40:00Z" }
   ]
 }

--- a/specs/019-add-all-filter/.spec-context.json
+++ b/specs/019-add-all-filter/.spec-context.json
@@ -1,0 +1,104 @@
+{
+  "workflow": "sdd",
+  "currentStep": "implement",
+  "currentTask": null,
+  "progress": "commit-review",
+  "next": "implement",
+  "updated": "2026-04-23",
+  "selectedAt": "2026-04-23T12:25:04Z",
+  "specName": "Add All Filter",
+  "branch": "main",
+  "workingBranch": "feat/add-all-filter",
+  "type": "feat",
+  "createdAt": "2026-04-23T12:25:04Z",
+  "approach": "Make the implicit 'all' filter state visible by prepending an All chip to each tool's filterOptions array, then remove the click-to-deselect toggle in the shared ToolbarToolHeaderComponent since the explicit All chip now serves as the reset affordance.",
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 8,
+      "scenarios": 6,
+      "key_finding": "Three tools share ToolbarToolHeaderComponent but their filterOptions arrays omit 'all'; click-to-deselect resets activeFilter to 'all' which onFilterChange silently drops — the filter sticks while the UI shows no active chip."
+    },
+    "plan": {
+      "approach_summary": "Make the implicit 'all' filter state visible by prepending an All chip to each tool's filterOptions array, then remove the click-to-deselect toggle in the shared ToolbarToolHeaderComponent since the explicit All chip now serves as the reset affordance.",
+      "files_planned": 7,
+      "risks": [
+        "Shared-header behavior change: removing click-to-deselect in ToolbarToolHeaderComponent is a visible UX shift — contained because only the three updated tools consume it."
+      ]
+    }
+  },
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Removed click-to-deselect branch in onFilterClick so it always sets activeFilter to the clicked value; deleted the unused defaultFilter input and its doc comment.",
+      "files": ["libs/ngx-dev-toolbar/src/components/tool-header/tool-header.component.ts"],
+      "concerns": []
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Prepended { value: 'all', label: 'All' } to filterOptions in the Feature Flags tool; added a regression test inside 'component logic' describe that confirms re-clicking the same filter keeps it active.",
+      "files": [
+        "libs/ngx-dev-toolbar/src/tools/feature-flags-tool/feature-flags-tool.component.ts",
+        "libs/ngx-dev-toolbar/src/tools/feature-flags-tool/feature-flags-tool.component.spec.ts"
+      ],
+      "concerns": [
+        "Spec had no filterOptions length/index assertions to update; added new it() inside the existing 'component logic' describe (no filter-focused describe exists in this file)."
+      ]
+    },
+    "T003": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "Prepended { value: 'all', label: 'All' } to filterOptions in the App Features tool; replaced the stub spec file with a TestBed-based suite including a regression test for re-clicking the same filter.",
+      "files": [
+        "libs/ngx-dev-toolbar/src/tools/app-features-tool/app-features-tool.component.ts",
+        "libs/ngx-dev-toolbar/src/tools/app-features-tool/app-features-tool.component.spec.ts"
+      ],
+      "concerns": [
+        "Initial subagent attempt instantiated the component with `new ToolbarAppFeaturesToolComponent()`, which throws NG0203 because the component uses property-level inject() for internal + storage services. Main thread rewrote the spec using TestBed.configureTestingModule with mocks for ToolbarInternalAppFeaturesService, ToolbarStorageService, and ToolbarStateService — mirrors the pattern already used by feature-flags-tool.component.spec.ts. Pre-existing spec was a stub (only a toBeDefined assertion) — no existing tests were lost."
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Prepended { value: 'all', label: 'All' } to filterOptions in the Permissions tool; updated the hard-coded filterOptions length (3 → 4) and index assertions to reflect the All-first ordering; added a regression test inside the existing 'filter dropdown functionality' describe.",
+      "files": [
+        "libs/ngx-dev-toolbar/src/tools/permissions-tool/permissions-tool.component.ts",
+        "libs/ngx-dev-toolbar/src/tools/permissions-tool/permissions-tool.component.spec.ts"
+      ],
+      "concerns": []
+    }
+  },
+  "files_modified": [
+    "libs/ngx-dev-toolbar/src/components/tool-header/tool-header.component.ts",
+    "libs/ngx-dev-toolbar/src/tools/feature-flags-tool/feature-flags-tool.component.ts",
+    "libs/ngx-dev-toolbar/src/tools/feature-flags-tool/feature-flags-tool.component.spec.ts",
+    "libs/ngx-dev-toolbar/src/tools/app-features-tool/app-features-tool.component.ts",
+    "libs/ngx-dev-toolbar/src/tools/app-features-tool/app-features-tool.component.spec.ts",
+    "libs/ngx-dev-toolbar/src/tools/permissions-tool/permissions-tool.component.ts",
+    "libs/ngx-dev-toolbar/src/tools/permissions-tool/permissions-tool.component.spec.ts"
+  ],
+  "decisions": [
+    "T003 silent fix: replaced bare `new Component()` instantiation with TestBed + mocked providers to match the feature-flags spec pattern. Needed because property-level inject() only resolves inside an injection context."
+  ],
+  "concerns": [
+    { "task": "T002", "note": "New regression test placed in 'component logic' describe block (no filter-focused describe exists). Low-risk organizational choice." },
+    { "task": "T003", "note": "Subagent wrote invalid `new Component()` test; main thread rewrote with TestBed before phase close. Test file pre-existed as stub, so this is a net improvement in coverage." }
+  ],
+  "last_action": "CP1 approved; at CP3 commit review",
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-23T12:25:04Z" },
+    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-23T12:25:05Z" },
+    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-04-23T12:25:30Z" },
+    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-04-23T12:25:40Z" },
+    { "step": "specify", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-04-23T12:26:00Z" },
+    { "step": "plan", "substep": "loading", "from": { "step": "specify", "substep": null }, "by": "sdd", "at": "2026-04-23T12:27:00Z" },
+    { "step": "plan", "substep": "writing-plan", "from": { "step": "plan", "substep": "loading" }, "by": "sdd", "at": "2026-04-23T12:27:15Z" },
+    { "step": "plan", "substep": null, "from": { "step": "plan", "substep": "writing-plan" }, "by": "sdd", "at": "2026-04-23T12:27:45Z" },
+    { "step": "tasks", "substep": "loading", "from": { "step": "plan", "substep": null }, "by": "sdd", "at": "2026-04-23T12:28:00Z" },
+    { "step": "tasks", "substep": "writing-tasks", "from": { "step": "tasks", "substep": "loading" }, "by": "sdd", "at": "2026-04-23T12:28:10Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "tasks", "substep": "writing-tasks" }, "by": "sdd", "at": "2026-04-23T12:28:30Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-04-23T12:29:00Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-23T12:30:00Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-23T12:32:00Z" },
+    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-23T12:34:00Z" },
+    { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-23T12:36:00Z" }
+  ]
+}

--- a/specs/019-add-all-filter/plan.md
+++ b/specs/019-add-all-filter/plan.md
@@ -1,0 +1,53 @@
+# Plan: Add All Filter
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-23
+
+## Approach
+
+Make the implicit `'all'` filter state visible by prepending an **All** chip to each tool's `filterOptions` array, then remove the click-to-deselect toggle in the shared `ToolbarToolHeaderComponent` since the explicit **All** chip now serves as the reset affordance. This keeps each tool's existing `FeatureFlagFilter` / `AppFeatureFilter` / `PermissionFilter` union (which already includes `'all'`) and its `activeFilter` signal default of `'all'` — no model changes, no persisted-state migrations. The only behavior change in the shared header is a one-line simplification: a chip click always sets `activeFilter` to the clicked value, never to a hidden default.
+
+## Technical Context
+
+**Stack**: Angular 21.1 standalone components, OnPush change detection, signal-based state (`signal()`, `computed()`, `model()`), TypeScript 5.5.
+**Key Dependencies**: `ToolbarToolHeaderComponent` (shared), `ToolbarStorageService` for localStorage-persisted view state.
+**Constraints**: All three tools must behave identically; no change to the filter-union types; `ToolViewState` persistence format stays unchanged for backwards compatibility.
+
+## Architecture
+
+```mermaid
+graph LR
+  A[feature-flags-tool.component] -->|filterOptions| H[ndt-tool-header]
+  B[app-features-tool.component] -->|filterOptions| H
+  C[permissions-tool.component] -->|filterOptions| H
+  H -->|activeFilterChange| A
+  H -->|activeFilterChange| B
+  H -->|activeFilterChange| C
+```
+
+Today only three tools consume `ndt-tool-header` with a `filterOptions` array (grep confirms). The change is isolated to those four files plus their specs.
+
+## Files
+
+### Create
+
+_(none)_
+
+### Modify
+
+- `libs/ngx-dev-toolbar/src/components/tool-header/tool-header.component.ts` — remove the click-to-deselect branch in `onFilterClick` (the `if (this.activeFilter() === value)` guard that resets to `defaultFilter()`); drop the now-unused `defaultFilter` input and its doc comment. A click always sets `activeFilter` to the clicked value.
+- `libs/ngx-dev-toolbar/src/tools/feature-flags-tool/feature-flags-tool.component.ts` — prepend `{ value: 'all', label: 'All' }` to `filterOptions`. No handler change needed: `onFilterChange` already looks up by `.find(f => f.value === value)` and will now succeed for `'all'`.
+- `libs/ngx-dev-toolbar/src/tools/app-features-tool/app-features-tool.component.ts` — same change: prepend `{ value: 'all', label: 'All' }` to `filterOptions`.
+- `libs/ngx-dev-toolbar/src/tools/permissions-tool/permissions-tool.component.ts` — same change: prepend `{ value: 'all', label: 'All' }` to `filterOptions`.
+- `libs/ngx-dev-toolbar/src/tools/feature-flags-tool/feature-flags-tool.component.spec.ts` — update any `filterOptions.length`/index-based assertions to expect the new All-first ordering; add a test covering the regression case from the spec (clicking the same chip twice keeps it active).
+- `libs/ngx-dev-toolbar/src/tools/app-features-tool/app-features-tool.component.spec.ts` — same spec updates.
+- `libs/ngx-dev-toolbar/src/tools/permissions-tool/permissions-tool.component.spec.ts` — same spec updates (existing assertions at lines 142–145 hard-code `length === 3` and `[0].value === 'forced'`; both need updating).
+
+## Testing Strategy
+
+- **Unit**: Jest component specs for all three tools. Assert (a) `filterOptions` has 4 entries with `'all'` at index 0; (b) `onFilterChange('all')` sets `activeFilter` to `'all'` and the filtered-list computed returns every item; (c) clicking an already-active chip (simulated by calling `onFilterChange` twice with the same value) leaves `activeFilter` unchanged.
+- **Integration**: Existing `loadViewState` tests already cover legacy persisted `'all'` values — no new tests needed for backwards-compat.
+- **Edge cases**: None beyond the scenarios listed in spec.md; the per-tool filter logic itself is untouched.
+
+## Risks
+
+- **Shared-header behavior change**: Removing click-to-deselect in `ToolbarToolHeaderComponent` is a visible UX shift — but the component is only consumed by the three tools being updated in the same PR, so the blast radius is contained. Mitigation: audit `grep ndt-tool-header` before merge (confirmed only 3 call sites today) and call out the behavior change in the commit message.

--- a/specs/019-add-all-filter/spec.md
+++ b/specs/019-add-all-filter/spec.md
@@ -1,0 +1,63 @@
+# Spec: Add All Filter
+
+**Slug**: 019-add-all-filter | **Date**: 2026-04-23
+
+## Summary
+
+Add an explicit **All** chip to the filter chip-group in the Feature Flags, App Features, and Permissions tools. Today the `all` state is implicit (no chip highlighted) and clicking an already-active chip silently resets to this invisible state — which users read as "my click broke the filter". An explicit "All" option makes the reset behavior discoverable and removes the stuck-filter bug caused by the handler ignoring the `'all'` value.
+
+## Requirements
+
+- **R001** (MUST): The Feature Flags, App Features, and Permissions tools MUST expose an **All** chip as the first option in their filter chip-group (ordered: All → Forced → Enabled/Granted → Disabled/Denied).
+- **R002** (MUST): Clicking the **All** chip MUST set the tool's `activeFilter` signal to `'all'` and show every item in the list (no state-based filtering applied), regardless of which chip was previously active.
+- **R003** (MUST): When `activeFilter` equals `'all'`, the **All** chip MUST appear visually active (`filter-segment--active` styling, `aria-checked="true"`), and no other chip in the group MUST appear active.
+- **R004** (MUST): On first open of a tool (no persisted view state), the **All** chip MUST be the active chip (matching the `activeFilter` initial value of `'all'`).
+- **R005** (MUST): Each tool's `onFilterChange(value)` handler MUST accept `'all'` as a valid value and update `activeFilter` accordingly — it must no longer silently drop unrecognized-but-valid filter values.
+- **R006** (MUST): Clicking an already-active chip (including **All**) MUST leave the filter state on that chip — i.e., the chip stays visibly active and the filter stays applied. The implicit "click-to-deselect" toggle in `ToolbarToolHeaderComponent` MUST be removed or neutralized, since "All" now serves as the explicit reset affordance.
+- **R007** (SHOULD): Filter view state persisted in localStorage MUST remain backwards-compatible — existing saved values of `'all'`, `'forced'`, `'enabled'`, `'disabled'`, `'granted'`, `'denied'` MUST all load without error and render the correct active chip.
+- **R008** (SHOULD): Keyboard navigation (`ArrowLeft`/`ArrowRight`/`Home`/`End`) within the chip-group MUST include the **All** chip in the navigation cycle.
+
+## Scenarios
+
+### First-open state
+
+**When** the user opens the Feature Flags tool for the first time (no localStorage state)
+**Then** the **All** chip appears as the active chip, and all feature flags are listed
+
+### Clicking "All" from a filtered state
+
+**When** the user has the **Forced** chip active (showing only forced flags) and clicks the **All** chip
+**Then** the **All** chip becomes the active chip, the **Forced** chip becomes inactive, and the list shows every flag
+
+### Clicking the currently-active chip (regression case)
+
+**When** the user has the **Forced** chip active and clicks **Forced** again
+**Then** the **Forced** chip remains active and the list continues to show only forced flags (no silent reset to an invisible `all` state)
+
+### Persistence across sessions
+
+**When** the user sets the filter to **Enabled** in the App Features tool and reopens the tool in a new session
+**Then** the **Enabled** chip is the active chip and only enabled features are shown
+
+### Legacy persisted state
+
+**When** localStorage contains a previously-saved view state with `filter: 'all'` (from before this change)
+**Then** the tool loads without error and the **All** chip appears active
+
+### Consistency across tools
+
+**When** the user opens each of the three tools (Feature Flags, App Features, Permissions)
+**Then** each tool's filter chip-group shows **All** as the leftmost option, followed by the tool's state-specific chips in their original order
+
+## Non-Functional Requirements
+
+- **NFR001** (MUST): The **All** chip MUST use the same visual styling, sizing, and spacing as existing filter chips — no layout regression within the tool header.
+- **NFR002** (SHOULD): The chip-group MUST remain accessible: `role="radiogroup"` on the container, `role="radio"` + correct `aria-checked` on each chip, and keyboard navigation unaffected other than including the new chip.
+
+## Out of Scope
+
+- Changing the underlying filter logic (how items are filtered by state) — only the chip set and click-reset behavior change.
+- Adding filter chips to tools that currently have none (i18n, Presets, Home, Network Mocker, Request Mocker).
+- Introducing new filter states (e.g., a "Modified" or "Recent" filter) — only **All** is added.
+- Redesigning the chip-group's visual style or converting it to a different control (dropdown, segmented switch, etc.).
+- Renaming existing filter values in localStorage-persisted state (backwards-compatibility required).

--- a/specs/019-add-all-filter/tasks.md
+++ b/specs/019-add-all-filter/tasks.md
@@ -1,0 +1,34 @@
+# Tasks: Add All Filter
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-23
+
+## Format
+
+- `[P]` marks tasks that can run in parallel with adjacent `[P]` tasks.
+- Consecutive `[P]` tasks form a **parallel group** — `/sdd:implement` spawns them as concurrent subagents.
+- Tasks without `[P]` are **gates**: they start only after all prior tasks complete.
+- Two tasks that touch the same file are never both `[P]`.
+
+---
+
+## Phase 1: Core Implementation
+
+- [x] **T001** Simplify tool-header filter-click behavior — `libs/ngx-dev-toolbar/src/components/tool-header/tool-header.component.ts` | R006, R008
+  - **Do**: In `onFilterClick(value)`, remove the `if (this.activeFilter() === value) { this.activeFilter.set(this.defaultFilter()); }` branch so a click always calls `this.activeFilter.set(value)`. Delete the `defaultFilter = input<string>('all')` declaration and its preceding doc comment (lines 74–79). Verified no external callers set `defaultFilter` — safe to drop.
+  - **Verify**: `nx lint ngx-dev-toolbar` passes; `nx test ngx-dev-toolbar` green. Clicking an already-active chip in any of the three consuming tools leaves the chip highlighted (manual check in demo app).
+  - **Leverage**: current `onFilterClick` at `tool-header.component.ts:85-93` is the only function changing; `onFilterKeydown` (keyboard nav) already sets `activeFilter` unconditionally and needs no change — R008 is satisfied automatically once `'all'` is in each tool's `filterOptions`.
+
+- [x] **T002** [P] Add All chip to Feature Flags tool *(depends on T001)* — `libs/ngx-dev-toolbar/src/tools/feature-flags-tool/feature-flags-tool.component.ts` and `…/feature-flags-tool.component.spec.ts` | R001, R002, R003, R004, R005
+  - **Do**: In `feature-flags-tool.component.ts:264-268`, prepend `{ value: 'all', label: 'All' }` to `filterOptions` so the array becomes `[all, forced, enabled, disabled]`. No handler change needed — `onFilterChange('all')` already finds a match via `.find(f => f.value === value)` and sets the signal. In the spec file, update any assertion that hard-codes `filterOptions.length === 3` or index-zero being `'forced'` to reflect the new All-first ordering; add a test: call `component.onFilterChange('forced')` twice, assert `activeFilter()` remains `'forced'` (the regression case from spec.md).
+  - **Verify**: `nx test ngx-dev-toolbar --testPathPattern feature-flags` green. Badge count, filtered-list computed, and localStorage round-trip still work (existing tests cover this).
+  - **Leverage**: `flagValueOptions` in the same file (same array-of-`{value,label}` shape); the internal filter-union `FeatureFlagFilter` at `feature-flags.models.ts:13` already includes `'all'` — no model change required.
+
+- [x] **T003** [P] Add All chip to App Features tool *(depends on T001)* — `libs/ngx-dev-toolbar/src/tools/app-features-tool/app-features-tool.component.ts` and `…/app-features-tool.component.spec.ts` | R001, R002, R003, R004, R005
+  - **Do**: In `app-features-tool.component.ts:288-292`, prepend `{ value: 'all', label: 'All' }` to `filterOptions`. Update the spec file's `filterOptions.length`/index-based assertions to expect the All-first ordering; add the same re-click regression test (two `onFilterChange('forced')` calls → `activeFilter()` stays `'forced'`).
+  - **Verify**: `nx test ngx-dev-toolbar --testPathPattern app-features` green.
+  - **Leverage**: structurally identical to T002 — copy the same chip entry and test pattern. `AppFeatureFilter` at `app-features.models.ts:80` already includes `'all'`.
+
+- [x] **T004** [P] Add All chip to Permissions tool *(depends on T001)* — `libs/ngx-dev-toolbar/src/tools/permissions-tool/permissions-tool.component.ts` and `…/permissions-tool.component.spec.ts` | R001, R002, R003, R004, R005, R007
+  - **Do**: In `permissions-tool.component.ts:289-293`, prepend `{ value: 'all', label: 'All' }` to `filterOptions`. In `permissions-tool.component.spec.ts`, update the hard-coded assertions at lines 142–145 (`filterOptions.length === 3`, `[0].value === 'forced'`, `[1].value === 'granted'`, `[2].value === 'denied'`) to reflect the new 4-entry All-first ordering. The existing test at line 213–219 (`onFilterChange('all')` shows all permissions) stays as-is — it will now exercise the previously-dead handler path. Add the re-click regression test.
+  - **Verify**: `nx test ngx-dev-toolbar --testPathPattern permissions` green. The existing `loadViewState` test at spec line ~98 confirms R007 (legacy `'all'` value loads correctly).
+  - **Leverage**: same pattern as T002/T003; `PermissionFilter` at `permissions.models.ts:36` already includes `'all'`.


### PR DESCRIPTION
## What

- Add explicit **All** chip as the first option in Feature Flags, App Features, and Permissions tool filter groups
- Remove the click-to-deselect reset branch in `ToolbarToolHeaderComponent` — the All chip now serves as the explicit reset affordance
- Add regression tests in all three tool specs covering the "re-click active chip keeps filter" scenario

## Why

Today, clicking an already-active filter chip silently resets `activeFilter` to a hidden `'all'` state that each tool's `onFilterChange` handler then drops — the filter gets stuck applied while the UI shows no active chip. An explicit **All** chip makes the reset discoverable and fixes the stuck-filter bug.

## Testing

- `nx test ngx-dev-toolbar` — all 173 tests pass
- `npm run code-check` — lint + test + build green across 3 projects
- New regression tests cover re-clicking the same filter in each of the three tools
- Manual verification: clicking **All** shows every item; clicking the active chip keeps the filter applied