### PR TITLE
fix(list-item): dot indicator reflects source value, not forced override

### DIFF
--- a/libs/ngx-dev-toolbar/src/components/list-item/list-item.component.spec.ts
+++ b/libs/ngx-dev-toolbar/src/components/list-item/list-item.component.spec.ts
@@ -77,4 +77,56 @@ describe('ToolbarListItemComponent', () => {
     const pinButton = fixture.nativeElement.querySelector('.pin-button');
     expect(pinButton.classList.contains('pin-button--pinned')).toBe(false);
   });
+
+  describe('source-value dot indicator', () => {
+    it('renders dot in source style when forced value differs from source', () => {
+      fixture.componentRef.setInput('currentValue', true);
+      fixture.componentRef.setInput('originalValue', false);
+      fixture.componentRef.setInput('isForced', true);
+      fixture.detectChanges();
+
+      const dot = fixture.nativeElement.querySelector('.dot-indicator');
+      expect(dot.classList).toContain('dot-indicator--off');
+      expect(dot.classList).not.toContain('dot-indicator--on');
+      expect(dot.classList).toContain('dot-indicator--forced');
+      expect(dot.getAttribute('title')).toMatch(/Server: disabled · Forced: enabled/);
+      expect(dot.getAttribute('aria-label')).toBe('disabled, forced');
+    });
+
+    it('renders dot in source style and simple tooltip when forced value matches source', () => {
+      fixture.componentRef.setInput('currentValue', true);
+      fixture.componentRef.setInput('originalValue', true);
+      fixture.componentRef.setInput('isForced', true);
+      fixture.detectChanges();
+
+      const dot = fixture.nativeElement.querySelector('.dot-indicator');
+      expect(dot.classList).toContain('dot-indicator--on');
+      expect(dot.classList).toContain('dot-indicator--forced');
+      expect(dot.getAttribute('title')).toBe('Currently enabled');
+      expect(dot.getAttribute('aria-label')).toBe('enabled, forced');
+    });
+
+    it('falls through to currentValue for non-forced items', () => {
+      fixture.componentRef.setInput('currentValue', true);
+      fixture.componentRef.setInput('isForced', false);
+      fixture.detectChanges();
+
+      const dot = fixture.nativeElement.querySelector('.dot-indicator');
+      expect(dot.classList).toContain('dot-indicator--on');
+      expect(dot.classList).not.toContain('dot-indicator--forced');
+      expect(dot.getAttribute('title')).toBe('Currently enabled');
+      expect(dot.getAttribute('aria-label')).toBe('enabled');
+    });
+
+    it('falls back to currentValue when forced but originalValue is undefined', () => {
+      fixture.componentRef.setInput('currentValue', true);
+      fixture.componentRef.setInput('isForced', true);
+      fixture.detectChanges();
+
+      const dot = fixture.nativeElement.querySelector('.dot-indicator');
+      expect(dot.classList).toContain('dot-indicator--on');
+      expect(dot.classList).toContain('dot-indicator--forced');
+      expect(dot.getAttribute('title')).toBe('Currently enabled');
+    });
+  });
 });

--- a/libs/ngx-dev-toolbar/src/components/list-item/list-item.component.ts
+++ b/libs/ngx-dev-toolbar/src/components/list-item/list-item.component.ts
@@ -28,8 +28,8 @@ import { IconName } from '../icons/icon.models';
     <div class="list-item" [class.list-item--forced]="isForced()">
       <span
         class="dot-indicator"
-        [class.dot-indicator--on]="currentValue()"
-        [class.dot-indicator--off]="!currentValue()"
+        [class.dot-indicator--on]="sourceValue()"
+        [class.dot-indicator--off]="!sourceValue()"
         [class.dot-indicator--forced]="isForced()"
         [title]="tooltipText()"
         [attr.aria-label]="statusAriaLabel()"
@@ -163,22 +163,34 @@ export class ToolbarListItemComponent {
   );
 
   /**
+   * Source-of-truth value for the dot indicator. When an item is forced and the
+   * upstream original value is known, surface that; otherwise fall back to
+   * currentValue. Decouples the dot color from the developer's override so the
+   * server-reported state remains visible at a glance.
+   */
+  protected sourceValue = computed(() => {
+    const original = this.originalValue();
+    return this.isForced() && original !== undefined ? original : this.currentValue();
+  });
+
+  /**
    * Tooltip text explaining the current state, with override context when forced
    */
   protected tooltipText = computed(() => {
     const current = this.currentValue() ? 'enabled' : 'disabled';
+    const original = this.originalValue();
 
-    if (this.isForced() && this.originalValue() !== undefined) {
-      const original = this.originalValue() ? 'enabled' : 'disabled';
-      return `Currently ${current} (originally ${original})`;
+    if (this.isForced() && original !== undefined && original !== this.currentValue()) {
+      const originalLabel = original ? 'enabled' : 'disabled';
+      return `Server: ${originalLabel} · Forced: ${current}`;
     }
 
     return `Currently ${current}`;
   });
 
   protected statusAriaLabel = computed(() => {
-    const current = this.currentValue() ? 'enabled' : 'disabled';
-    return this.isForced() ? `${current}, forced` : current;
+    const source = this.sourceValue() ? 'enabled' : 'disabled';
+    return this.isForced() ? `${source}, forced` : source;
   });
 
   protected readonly copyState = signal<'idle' | 'copied'>('idle');

--- a/specs/020-fix-flag-source-display/.spec-context.json
+++ b/specs/020-fix-flag-source-display/.spec-context.json
@@ -1,0 +1,300 @@
+{
+  "workflow": "sdd",
+  "currentStep": "done",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "status": "completed",
+  "checkpointStatus": {
+    "commit": true,
+    "pr": false
+  },
+  "updated": "2026-05-08",
+  "selectedAt": "2026-04-27T00:16:00Z",
+  "specName": "Fix Flag Source Display",
+  "branch": "main",
+  "workingBranch": "fix/list-item-dot-indicator-source-value",
+  "type": "fix",
+  "createdAt": "2026-04-27T00:16:00Z",
+  "approach": "Decouple the dot indicator in ndt-list-item from the forced/effective value so it always renders the upstream source value, while leaving the row tint, select dropdown, and aria semantics untouched.",
+  "last_action": "All 3 tasks complete; CP1+CP3 approved; pre:commit hook (npm run code-check) passed lint+test+build; 012 sidecar deleted (was untracked, no commit); ready to commit and PR.",
+  "files_modified": [
+    "libs/ngx-dev-toolbar/src/components/list-item/list-item.component.ts",
+    "libs/ngx-dev-toolbar/src/components/list-item/list-item.component.spec.ts"
+  ],
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Added sourceValue computed; switched dot-indicator--on/--off bindings to sourceValue(); rewrote tooltipText to surface 'Server: X · Forced: Y' on divergence; rewrote statusAriaLabel to announce source value with 'forced' qualifier.",
+      "files": [
+        "libs/ngx-dev-toolbar/src/components/list-item/list-item.component.ts"
+      ],
+      "concerns": []
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Added 4 Jest cases under nested 'source-value dot indicator' describe block: forced+diverging, forced+matching, non-forced regression guard, defensive originalValue=undefined fallback. Adapted CONTINUATION's pseudocode to match existing spec's `title` (not `label`) input convention and reused its TestBed.createComponent + setInput pattern.",
+      "files": [
+        "libs/ngx-dev-toolbar/src/components/list-item/list-item.component.spec.ts"
+      ],
+      "concerns": []
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Verification only — pre-flight grep confirmed [showApply]=\"hasApplyCallback()\" wired in feature-flags-tool.component.ts:122, permissions-tool.component.ts:145, app-features-tool.component.ts:150, and the @if (showApply() && isForced()) guard exists at list-item.component.ts:61. All 3 tool component specs pass in the full library run.",
+      "files": [],
+      "concerns": []
+    }
+  },
+  "decisions": [
+    "Branch named fix/list-item-dot-indicator-source-value (per CONTINUATION.md) instead of the .sdd.json default fix/fix-flag-source-display, to avoid the type/slug stutter and keep the descriptive name the user pre-chose.",
+    "T002 test cases use existing nested describe convention rather than CONTINUATION's `label` input — the actual component input is `title`."
+  ],
+  "concerns": [],
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 9,
+      "scenarios": 6,
+      "key_finding": "feature-flags-internal.service.ts already preserves the source value as `originalValue` when an item is forced, but the shared ndt-list-item dot indicator only binds to `currentValue` (the effective/forced value) — the server value is computed but never rendered."
+    },
+    "plan": {
+      "approach_summary": "Decouple the dot indicator in ndt-list-item from the forced/effective value so it always renders the upstream source value, while leaving the row tint, select dropdown, and aria semantics untouched.",
+      "files_planned": 2,
+      "risks": [
+        "Tooltip / aria-label drift: dot describes source value while row tint and select describe forced value — must update tooltipText and statusAriaLabel in the same change.",
+        "Hidden consumers of currentValue semantics: only change the dot binding and tied computeds; leave the currentValue input contract intact so the select dropdown and forced row tint continue to work."
+      ]
+    },
+    "tasks": {
+      "task_count": 3,
+      "parallel_groups": 1,
+      "files_touched": 2,
+      "key_finding": "Apply-to-source button gating (R005/R006) collapses to a verification task — the `@if (showApply() && isForced())` guard already exists in list-item.component.ts:61."
+    }
+  },
+  "transitions": [
+    {
+      "step": "specify",
+      "substep": "parsing",
+      "from": null,
+      "by": "sdd",
+      "at": "2026-04-27T00:16:00Z"
+    },
+    {
+      "step": "specify",
+      "substep": "exploring",
+      "from": "parsing",
+      "by": "sdd",
+      "at": "2026-04-27T00:16:30Z"
+    },
+    {
+      "step": "specify",
+      "substep": "detecting",
+      "from": "exploring",
+      "by": "sdd",
+      "at": "2026-04-27T00:17:00Z"
+    },
+    {
+      "step": "specify",
+      "substep": "writing-spec",
+      "from": "detecting",
+      "by": "sdd",
+      "at": "2026-04-27T00:17:10Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": "writing-spec",
+      "by": "sdd",
+      "at": "2026-04-27T00:17:30Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-27T00:25:53.148Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-27T00:25:53.151Z"
+    },
+    {
+      "step": "plan",
+      "substep": "research",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-04-27T00:30:00Z"
+    },
+    {
+      "step": "plan",
+      "substep": "design",
+      "from": {
+        "step": "plan",
+        "substep": "research"
+      },
+      "by": "sdd",
+      "at": "2026-04-27T00:32:00Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": "design"
+      },
+      "by": "sdd",
+      "at": "2026-04-27T00:35:00Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-27T00:34:21.419Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-27T00:34:21.421Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "writing-tasks",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-04-27T00:40:00Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "generate",
+      "from": {
+        "step": "tasks",
+        "substep": "writing-tasks"
+      },
+      "by": "sdd",
+      "at": "2026-04-27T00:40:00Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": "generate"
+      },
+      "by": "sdd",
+      "at": "2026-04-27T00:42:00Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-08T00:00:00Z"
+    },
+    {
+      "step": "implement",
+      "substep": "hooks",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-08T00:01:00Z"
+    },
+    {
+      "step": "implement",
+      "substep": "code-review",
+      "from": {
+        "step": "implement",
+        "substep": "hooks"
+      },
+      "by": "sdd",
+      "at": "2026-05-08T00:02:00Z"
+    },
+    {
+      "step": "implement",
+      "substep": "commit-review",
+      "from": {
+        "step": "implement",
+        "substep": "code-review"
+      },
+      "by": "sdd",
+      "at": "2026-05-08T00:03:00Z"
+    },
+    {
+      "step": "done",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": "commit-review"
+      },
+      "by": "sdd",
+      "at": "2026-05-08T00:04:00Z"
+    }
+  ],
+  "stepHistory": {
+    "specify": {
+      "startedAt": "2026-04-27T00:25:53.148Z",
+      "completedAt": "2026-04-27T00:25:53.148Z"
+    },
+    "plan": {
+      "startedAt": "2026-04-27T00:25:53.151Z",
+      "completedAt": "2026-04-27T00:34:21.419Z",
+      "substeps": [
+        {
+          "name": "research",
+          "startedAt": "2026-04-27T00:30:00Z",
+          "completedAt": "2026-04-27T00:32:00Z"
+        },
+        {
+          "name": "design",
+          "startedAt": "2026-04-27T00:32:00Z",
+          "completedAt": "2026-04-27T00:35:00Z"
+        }
+      ]
+    },
+    "tasks": {
+      "startedAt": "2026-04-27T00:34:21.421Z",
+      "completedAt": "2026-04-27T00:42:00Z",
+      "substeps": [
+        {
+          "name": "generate",
+          "startedAt": "2026-04-27T00:40:00Z",
+          "completedAt": "2026-04-27T00:42:00Z"
+        }
+      ]
+    },
+    "implement": {
+      "startedAt": "2026-05-08T00:00:00Z",
+      "completedAt": "2026-05-08T00:04:00Z"
+    }
+  }
+}

--- a/specs/020-fix-flag-source-display/.spec-context.json
+++ b/specs/020-fix-flag-source-display/.spec-context.json
@@ -7,8 +7,10 @@
   "status": "completed",
   "checkpointStatus": {
     "commit": true,
-    "pr": false
+    "pr": true
   },
+  "prUrl": "https://github.com/alfredoperez/ngx-dev-toolbar/pull/51",
+  "prNumber": 51,
   "updated": "2026-05-08",
   "selectedAt": "2026-04-27T00:16:00Z",
   "specName": "Fix Flag Source Display",
@@ -17,7 +19,7 @@
   "type": "fix",
   "createdAt": "2026-04-27T00:16:00Z",
   "approach": "Decouple the dot indicator in ndt-list-item from the forced/effective value so it always renders the upstream source value, while leaving the row tint, select dropdown, and aria semantics untouched.",
-  "last_action": "All 3 tasks complete; CP1+CP3 approved; pre:commit hook (npm run code-check) passed lint+test+build; 012 sidecar deleted (was untracked, no commit); ready to commit and PR.",
+  "last_action": "PR #51 opened — fix(list-item): dot indicator reflects source value, not forced override",
   "files_modified": [
     "libs/ngx-dev-toolbar/src/components/list-item/list-item.component.ts",
     "libs/ngx-dev-toolbar/src/components/list-item/list-item.component.spec.ts"
@@ -258,6 +260,16 @@
       },
       "by": "sdd",
       "at": "2026-05-08T00:04:00Z"
+    },
+    {
+      "step": "done",
+      "substep": "pr-opened",
+      "from": {
+        "step": "done",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-08T00:05:00Z"
     }
   ],
   "stepHistory": {

--- a/specs/020-fix-flag-source-display/CONTINUATION.md
+++ b/specs/020-fix-flag-source-display/CONTINUATION.md
@@ -1,0 +1,330 @@
+# Continuation: Fix Flag Source Display + Clean Up 012 Sidecar
+
+**Date written**: 2026-05-08
+**For**: A fresh session starting from `main` with no memory of how this got here.
+
+This document is self-contained. Read it cold, run the verification commands, then execute. The spec/plan/tasks files in this directory are authoritative for *what* to build; this document is authoritative for *what's already done* and *exactly which edits are still pending*.
+
+---
+
+## TL;DR
+
+Two pieces of leftover work that should ship together as one small PR:
+
+1. **Delete `specs/012-fix-hover-overflow/.spec-context.json`** — stale SDD workflow sidecar, the underlying feature already shipped via PR #35.
+2. **Implement spec 020 (Fix Flag Source Display)** — bug where the dot indicator next to each flag/permission/app-feature shows the *forced* value instead of the *source-of-truth* value. Most of the groundwork is already in place; only T001 (one component change) and T002 (unit tests) are pending.
+
+Estimated total work: 30–60 minutes including tests + PR.
+
+---
+
+## Pre-flight: verify the codebase still matches the plan
+
+Run these checks before editing. If any output diverges, stop and re-read the actual code instead of trusting this plan.
+
+```bash
+# 1. Confirm the dot binding still uses currentValue (T001 not started)
+grep -n "dot-indicator--on\|dot-indicator--off" libs/ngx-dev-toolbar/src/components/list-item/list-item.component.ts
+# Expected: lines binding `[class.dot-indicator--on]="currentValue()"` and `[class.dot-indicator--off]="!currentValue()"`
+
+# 2. Confirm `sourceValue` does NOT yet exist
+grep -n "sourceValue" libs/ngx-dev-toolbar/src/components/list-item/list-item.component.ts
+# Expected: no matches
+
+# 3. Confirm `originalValue` input exists (foundation already in place)
+grep -n "originalValue = input" libs/ngx-dev-toolbar/src/components/list-item/list-item.component.ts
+# Expected: line ~126 with `originalValue = input<boolean | undefined>(undefined);`
+
+# 4. Confirm [showApply] is wired in all three tools (T003 already complete — no code change needed)
+grep -n "\[showApply\]" \
+  libs/ngx-dev-toolbar/src/tools/feature-flags-tool/feature-flags-tool.component.ts \
+  libs/ngx-dev-toolbar/src/tools/permissions-tool/permissions-tool.component.ts \
+  libs/ngx-dev-toolbar/src/tools/app-features-tool/app-features-tool.component.ts
+# Expected: 3 hits, all binding to `hasApplyCallback()`
+
+# 5. Confirm 012 sidecar still exists and is untracked
+ls specs/012-fix-hover-overflow/.spec-context.json
+git ls-files specs/012-fix-hover-overflow/.spec-context.json
+# Expected: file exists, but `git ls-files` returns empty (untracked)
+```
+
+If everything matches, proceed.
+
+---
+
+## Branch + scope
+
+```bash
+git checkout main
+git pull origin main      # PR #50 may or may not be merged yet — either is fine, this branch's scope doesn't overlap
+git checkout -b fix/list-item-dot-indicator-source-value
+```
+
+**Scope of the PR:**
+
+- ✏️ Edit `libs/ngx-dev-toolbar/src/components/list-item/list-item.component.ts`
+- ✏️ Edit `libs/ngx-dev-toolbar/src/components/list-item/list-item.component.spec.ts`
+- 🗑️ Delete `specs/012-fix-hover-overflow/.spec-context.json`
+
+Nothing else. The `[showApply]` work (T003) is already done in `main`.
+
+---
+
+## What's already done (do NOT redo)
+
+These were verified by grep on 2026-05-08:
+
+- ✅ `originalValue = input<boolean | undefined>(undefined)` — `list-item.component.ts:126`
+- ✅ `tooltipText` already branches on `isForced() && originalValue() !== undefined` — `list-item.component.ts:171`
+- ✅ `[showApply]="hasApplyCallback()"` in:
+  - `feature-flags-tool.component.ts:122`
+  - `permissions-tool.component.ts:145`
+  - `app-features-tool.component.ts:150`
+- ✅ Each internal service exposes a `hasApplyCallback` computed driven by `applyCallback() !== null`
+
+---
+
+## T001 — exact edits to `list-item.component.ts`
+
+### Edit 1: Add `sourceValue` computed
+
+Find the existing computeds in the component class (around line 168, just above `tooltipText`). Insert:
+
+```typescript
+/**
+ * Source-of-truth value: when an item is forced and we know the original
+ * upstream value, expose that; otherwise fall back to currentValue.
+ *
+ * The dot indicator binds to this so it always reflects what the server /
+ * provider reported, never the developer's override.
+ */
+protected sourceValue = computed(() => {
+  const original = this.originalValue();
+  return this.isForced() && original !== undefined ? original : this.currentValue();
+});
+```
+
+### Edit 2: Switch dot bindings (template at the top of the file, ~lines 30-33)
+
+```diff
+   class="dot-indicator"
+-  [class.dot-indicator--on]="currentValue()"
+-  [class.dot-indicator--off]="!currentValue()"
++  [class.dot-indicator--on]="sourceValue()"
++  [class.dot-indicator--off]="!sourceValue()"
+   [class.dot-indicator--forced]="isForced()"
+```
+
+Leave `dot-indicator--forced` (and any `list-item--forced` row tint) bound to `isForced()` — the *forced* visual state is independent of the dot color.
+
+### Edit 3: Refresh `tooltipText` to use the spec wording
+
+Spec R007 wants `"Server: enabled · Forced: disabled"` style. The current `tooltipText` says `"Currently enabled (originally disabled)"`. Rewrite:
+
+```typescript
+protected tooltipText = computed(() => {
+  const current = this.currentValue() ? 'enabled' : 'disabled';
+  const original = this.originalValue();
+
+  if (this.isForced() && original !== undefined && original !== this.currentValue()) {
+    const originalLabel = original ? 'enabled' : 'disabled';
+    return `Server: ${originalLabel} · Forced: ${current}`;
+  }
+
+  return `Currently ${current}`;
+});
+```
+
+Note: when forced + values match, fall through to `"Currently <state>"` per spec scenario "Forced flag with matching source value".
+
+### Edit 4: Refresh `statusAriaLabel` to announce source value
+
+Current code uses `currentValue` for both forced and non-forced. Spec NFR001 wants the source value announced (with `, forced` qualifier when applicable):
+
+```typescript
+protected statusAriaLabel = computed(() => {
+  const source = this.sourceValue() ? 'enabled' : 'disabled';
+  return this.isForced() ? `${source}, forced` : source;
+});
+```
+
+---
+
+## T002 — exact tests to add to `list-item.component.spec.ts`
+
+Read the existing file first to learn the `TestBed.createComponent` + `componentRef.setInput` pattern. Then add four cases:
+
+```typescript
+describe('source-value dot indicator', () => {
+  // 1. Forced with diverging source → dot reflects source, tooltip shows both
+  it('renders dot in source style when forced value differs from source', () => {
+    const fixture = TestBed.createComponent(ToolbarListItemComponent);
+    fixture.componentRef.setInput('label', 'dark-mode');
+    fixture.componentRef.setInput('currentValue', true);
+    fixture.componentRef.setInput('originalValue', false);
+    fixture.componentRef.setInput('isForced', true);
+    fixture.detectChanges();
+
+    const dot = fixture.nativeElement.querySelector('.dot-indicator');
+    expect(dot.classList).toContain('dot-indicator--off');     // source = false
+    expect(dot.classList).not.toContain('dot-indicator--on');
+    expect(dot.classList).toContain('dot-indicator--forced');
+    expect(dot.getAttribute('title')).toMatch(/Server: disabled · Forced: enabled/);
+    expect(dot.getAttribute('aria-label')).toBe('disabled, forced');
+  });
+
+  // 2. Forced with matching source → dot still ok, tooltip is the simple form
+  it('renders dot in source style and simple tooltip when forced value matches source', () => {
+    const fixture = TestBed.createComponent(ToolbarListItemComponent);
+    fixture.componentRef.setInput('label', 'beta-features');
+    fixture.componentRef.setInput('currentValue', true);
+    fixture.componentRef.setInput('originalValue', true);
+    fixture.componentRef.setInput('isForced', true);
+    fixture.detectChanges();
+
+    const dot = fixture.nativeElement.querySelector('.dot-indicator');
+    expect(dot.classList).toContain('dot-indicator--on');
+    expect(dot.classList).toContain('dot-indicator--forced');
+    expect(dot.getAttribute('title')).toBe('Currently enabled');
+    expect(dot.getAttribute('aria-label')).toBe('enabled, forced');
+  });
+
+  // 3. Non-forced regression guard → dot tracks currentValue exactly as before
+  it('falls through to currentValue for non-forced items', () => {
+    const fixture = TestBed.createComponent(ToolbarListItemComponent);
+    fixture.componentRef.setInput('label', 'public-flag');
+    fixture.componentRef.setInput('currentValue', true);
+    fixture.componentRef.setInput('isForced', false);
+    fixture.detectChanges();
+
+    const dot = fixture.nativeElement.querySelector('.dot-indicator');
+    expect(dot.classList).toContain('dot-indicator--on');
+    expect(dot.classList).not.toContain('dot-indicator--forced');
+    expect(dot.getAttribute('title')).toBe('Currently enabled');
+  });
+
+  // 4. Defensive: forced but no originalValue → fall back to currentValue
+  it('falls back to currentValue when forced but originalValue is undefined', () => {
+    const fixture = TestBed.createComponent(ToolbarListItemComponent);
+    fixture.componentRef.setInput('label', 'mystery-flag');
+    fixture.componentRef.setInput('currentValue', true);
+    fixture.componentRef.setInput('isForced', true);
+    // originalValue intentionally not set
+    fixture.detectChanges();
+
+    const dot = fixture.nativeElement.querySelector('.dot-indicator');
+    expect(dot.classList).toContain('dot-indicator--on');
+    expect(dot.classList).toContain('dot-indicator--forced');
+  });
+});
+```
+
+Adjust input names if the existing spec file reveals different input identifiers (e.g., `label` may be `name`). Read the file first, mirror its conventions.
+
+---
+
+## 012 cleanup — one command
+
+```bash
+rm specs/012-fix-hover-overflow/.spec-context.json
+```
+
+That's the entire cleanup. Stage it as part of the same commit as the docs polish, or as its own separate `chore` commit.
+
+---
+
+## Commit + PR strategy
+
+**One PR, two commits:**
+
+```bash
+# Commit 1 — the actual fix
+git add \
+  libs/ngx-dev-toolbar/src/components/list-item/list-item.component.ts \
+  libs/ngx-dev-toolbar/src/components/list-item/list-item.component.spec.ts
+git commit -m "fix(list-item): dot indicator reflects source value, not forced override
+
+The dot next to each flag, permission, and app-feature was showing
+the developer's override instead of the value the source-of-truth
+reported. Decouple the dot binding from currentValue: when an item
+is forced and originalValue is known, the dot now reflects the
+upstream value. The amber row tint and 'forced' aria qualifier
+remain on the forced state so both pieces of information are visible
+at a glance.
+
+Tooltip wording adopts the 'Server: X · Forced: Y' format from spec
+020 when the values diverge, otherwise falls through to the existing
+'Currently X' phrasing.
+
+Closes spec 020."
+
+# Commit 2 — sidecar cleanup
+git rm specs/012-fix-hover-overflow/.spec-context.json
+git commit -m "chore: remove stale SDD context for already-shipped spec 012
+
+The hover-overflow fix shipped via PR #35 (commit 1ac6531). The
+.spec-context.json sidecar was never advanced past the 'specify' draft
+state and is no longer referenced by anything. Deleting to keep the
+specs/ directory honest about what's in flight."
+```
+
+Verify the chain:
+
+```bash
+git log main..HEAD --oneline
+# Expected:
+#   <hash> chore: remove stale SDD context for already-shipped spec 012
+#   <hash> fix(list-item): dot indicator reflects source value, not forced override
+```
+
+**Push + PR:**
+
+```bash
+git push -u origin fix/list-item-dot-indicator-source-value
+
+gh pr create --title "fix(list-item): dot indicator reflects source value, not forced override" --body "$(cat <<'EOF'
+## Summary
+- The list-item dot indicator now reflects the value the source of truth (server, LaunchDarkly, etc.) reported, not the developer's override. The amber row tint and 'forced' aria qualifier still convey that the item is forced.
+- Tooltip wording adopts \`Server: X · Forced: Y\` when the source and forced values diverge.
+- Removes the stale \`.spec-context.json\` sidecar from spec 012 (whose feature shipped via PR #35).
+
+## Why
+Spec 020 calls out that developers couldn't tell at a glance what production was actually returning when they had a value forced — the dot was always echoing the override. Decoupling the dot from \`currentValue\` lets both pieces of information surface in one place.
+
+## Changes
+- \`list-item.component.ts\`: new \`sourceValue\` computed; dot bindings switched; \`tooltipText\` and \`statusAriaLabel\` updated.
+- \`list-item.component.spec.ts\`: 4 new Jest cases covering forced+diverging, forced+matching, non-forced regression guard, and defensive \`originalValue=undefined\` fallback.
+- Deletes \`specs/012-fix-hover-overflow/.spec-context.json\`.
+
+## Already in place from prior work (verified, no change needed)
+- \`originalValue\` input on \`ndt-list-item\`
+- \`[showApply]="hasApplyCallback()"\` wired across feature-flags / permissions / app-features tools
+- Internal services exposing \`hasApplyCallback\`
+EOF
+)"
+```
+
+Ask the user for validation of title + body before running `gh pr create` (per their stated PR preference).
+
+---
+
+## Verification before merging
+
+```bash
+./node_modules/.bin/nx test ngx-dev-toolbar --testPathPattern=list-item
+./node_modules/.bin/nx build ngx-dev-toolbar --skip-nx-cache
+./node_modules/.bin/nx lint ngx-dev-toolbar
+```
+
+Visual smoke test (refresh the demo dev server):
+
+1. Force a feature flag whose source value is `false` to `true`. Confirm: dot is **red ring (off)**, row has **amber tint**, tooltip reads `Server: disabled · Forced: enabled`, screen reader announces `disabled, forced`.
+2. Force a flag whose source is already `true` to `true`. Confirm: dot is **filled green**, row has **amber tint**, tooltip reads `Currently enabled`, screen reader announces `enabled, forced`.
+3. Don't force a flag at all. Confirm: dot tracks the source value, no amber tint, tooltip reads `Currently <state>`. (Regression guard.)
+
+---
+
+## After merging
+
+- Mark T001/T002/T003 as ✅ in `specs/020-fix-flag-source-display/tasks.md`, or just delete the file if you don't keep tasks files post-ship.
+- The streaming-redesign PR (#50) is unrelated and on its own branch — this work doesn't block or unblock it.

--- a/specs/020-fix-flag-source-display/plan.md
+++ b/specs/020-fix-flag-source-display/plan.md
@@ -1,0 +1,38 @@
+# Plan: Fix Flag Source Display
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-26
+
+## Approach
+
+Decouple the dot indicator in `ndt-list-item` from the forced/effective value so it always renders the upstream source value, while leaving the row tint, select dropdown, and aria semantics untouched. The fix is a single-component change: introduce a `sourceValue` computed that returns `originalValue` when an item is forced (and that value is defined) and falls back to `currentValue` otherwise. R005/R006 (apply-to-source button gating) require **no code change** — every tool component already binds `[showApply]="hasApplyCallback()"` and the template already gates with `@if (showApply() && isForced())`; we will verify this during implementation rather than reintroduce the binding.
+
+## Technical Context
+
+**Stack**: Angular 19, TypeScript 5.5, Jest, signals (`computed`, `input`)
+**Constraints**: No public API changes; `originalValue` field is already present on `ToolbarFlag` / `ToolbarPermission` / `ToolbarAppFeature`, so no new state plumbing is needed.
+
+## Files
+
+### Create
+
+(none)
+
+### Modify
+
+- `libs/ngx-dev-toolbar/src/components/list-item/list-item.component.ts` — add `sourceValue` computed (forced + defined `originalValue` → `originalValue`; otherwise → `currentValue`), bind `dot-indicator--on/off` to `sourceValue()` instead of `currentValue()`, refresh `tooltipText` to surface "Server: X · Forced: Y" when the two diverge and a single-state line otherwise, refresh `statusAriaLabel` to announce the source value with a "forced" qualifier.
+- `libs/ngx-dev-toolbar/src/components/list-item/list-item.component.spec.ts` — add test cases: (a) forced with diverging source renders dot in source style and tooltip with both values, (b) forced with matching source renders dot in source style and single-state tooltip, (c) non-forced item dot still tracks `currentValue` (regression guard).
+
+## Testing Strategy
+
+- **Unit**: Add three `ToolbarListItemComponent` cases against the existing Jest suite, asserting `dot-indicator--on` / `dot-indicator--off` class presence based on `originalValue` when `isForced` is true, and tooltip + aria-label content for the diverging case.
+- **Integration**: Rely on existing `feature-flags-tool.component.spec.ts`, `permissions-tool.component.spec.ts`, and `app-features-tool.component.spec.ts` to confirm no regression in how each tool wires `originalValue` and `showApply` through to the list item.
+- **Edge cases**: Forced item with `originalValue === undefined` (defensive — fall back to `currentValue` so we never render a misleading dot); toolbar disabled (still no UI — covered by existing tool-component tests).
+
+## Risks
+
+- **Tooltip / aria-label drift**: The dot now describes the source value while the row tint and select describe the forced value. If we update the dot binding but leave `tooltipText` describing `currentValue`, screen reader users get contradictory cues. Mitigation: update `tooltipText` and `statusAriaLabel` in the same change and cover both with the new specs.
+- **Hidden consumers of `currentValue` semantics**: Other components or styles in the file may assume `currentValue` is the dot's source. Mitigation: only change the dot binding and the two computeds tied to it; leave `currentValue` input contract intact so the select dropdown and forced row tint continue to work as before.
+
+---
+
+**Plain-English summary** — the dot next to each flag, permission, and app-feature is showing the developer's override instead of the value the server actually reported, and the spec author wants those decoupled so you can see at a glance both what production says and what you've forced. The fix lives in one shared list-item component: make the dot read the original (server) value when an override exists, and update its tooltip and screen-reader label to mention both values when they disagree. The "apply to source" button gating asked for by the spec is already in place across all three tools, so that part of the fix is just a verification — no new code.

--- a/specs/020-fix-flag-source-display/spec.md
+++ b/specs/020-fix-flag-source-display/spec.md
@@ -1,0 +1,63 @@
+# Spec: Fix Flag Source Display
+
+**Slug**: 020-fix-flag-source-display | **Date**: 2026-04-26
+
+## Summary
+
+The list-item indicator dot in the feature-flags / permissions / app-features tools currently reflects the **forced (effective) value** rather than the value the source-of-truth (server, LaunchDarkly, etc.) reported. Additionally, the "Apply to source" action is rendered for items that do not have a configured apply-to-source integration, which misleads developers into thinking they can push a value back when no callback is wired up. This spec corrects both behaviours so the indicator faithfully reflects the upstream value and the apply action only appears when it is actually available.
+
+## Requirements
+
+- **R001** (MUST): The list-item dot indicator (green = on, red ring = off) MUST reflect the value reported by the source of truth — i.e., the original (non-forced) value passed in via `setAvailableOptions`. When a flag/permission/feature is forced, the dot MUST continue to show the source value, NOT the forced override.
+- **R002** (MUST): When an item is forced AND its forced value differs from the source value, the UI MUST still convey the forced state (existing amber row tint and "forced" aria label / tooltip remain). Only the dot color is decoupled from the forced value.
+- **R003** (MUST): When an item is forced AND its forced value equals the source value, the dot color and forced styling MUST remain visually consistent (no flicker, no contradictory cues).
+- **R004** (MUST): For non-forced items, dot behaviour MUST be unchanged — it already reflects the source value because `isEnabled` equals the source value in that case.
+- **R005** (MUST): The "Apply to source" icon button MUST NOT render when the consuming application has not registered an apply-to-source callback for that tool (i.e., `setApplyToSource()` was never called on the corresponding public service).
+- **R006** (MUST): The "Apply to source" icon button MUST only render when ALL of: (a) the consumer registered a callback, (b) the item is currently forced, (c) the toolbar is enabled.
+- **R007** (SHOULD): The tooltip on the dot indicator SHOULD distinguish source value from forced value when they diverge — e.g., "Server: enabled · Forced: disabled" — so developers can see both at a glance.
+- **R008** (SHOULD): The fix SHOULD apply uniformly to feature-flags, permissions, and app-features tools, since they share the `ndt-list-item` component and the same `setApplyToSource` pattern.
+- **R009** (MAY): A unit-test fixture MAY be added to `list-item.component.spec.ts` exercising forced-with-divergent-source and forced-with-matching-source paths, to lock the behaviour.
+
+## Scenarios
+
+### Forced flag with diverging source value
+
+**When** the source reports flag `dark-mode` as `false` AND a developer forces `dark-mode = true` via the toolbar
+**Then** the dot indicator renders in the **off** style (red outlined ring), the row shows the **forced** amber tint, the select shows **Forced On**, and the tooltip reads something like "Server: disabled · Forced: enabled"
+
+### Forced flag with matching source value
+
+**When** the source reports flag `beta-features` as `true` AND a developer forces `beta-features = true` via the toolbar
+**Then** the dot indicator renders in the **on** style (filled green), the row shows the **forced** amber tint (because it is still a forced override even if the value matches), and the tooltip simply reads "Currently enabled" (no divergence to surface)
+
+### Non-forced item
+
+**When** the source reports a flag/permission/feature value AND no override exists in the toolbar
+**Then** the dot indicator continues to reflect that source value exactly as before — no behavioural change
+
+### Apply-to-source not registered
+
+**When** the consuming app has NOT called `service.setApplyToSource(...)` AND a developer forces an item
+**Then** the "Apply to source" icon button MUST NOT render on that item, regardless of forced state
+
+### Apply-to-source registered, item forced
+
+**When** the consuming app HAS called `service.setApplyToSource(...)` AND the item is forced
+**Then** the "Apply to source" icon button renders and is interactive (existing behaviour preserved)
+
+### Toolbar disabled with forced items
+
+**When** the toolbar `enabled` config is `false` AND items in the underlying state are forced
+**Then** since the toolbar UI itself does not render, the apply button visibility is moot; this is verified only to ensure no regression when the toolbar is re-enabled
+
+## Non-Functional Requirements
+
+- **NFR001** (MUST): Accessibility — the dot's `aria-label` MUST stay accurate (announce the source value, plus a "forced" qualifier when applicable). Color is not the only signal — the ring vs. filled circle shape distinction for off/on remains.
+- **NFR002** (SHOULD): No new runtime cost beyond reading an existing `originalValue` field already present on `ToolbarFlag` / `ToolbarPermission` / `ToolbarAppFeature`.
+
+## Out of Scope
+
+- Changing the public API surface of `ToolbarFeatureFlagService`, `ToolbarPermissionsService`, or `ToolbarAppFeaturesService` — the fix is internal/UI-level.
+- Reworking how the override (forced) state is stored or computed in the internal services.
+- Adding a new "Apply to source" UX for items that are not forced (out of scope; the action only makes sense for forced items by design).
+- Migrating away from the deprecated `onApply*` config callbacks in `ToolbarConfig`.

--- a/specs/020-fix-flag-source-display/tasks.md
+++ b/specs/020-fix-flag-source-display/tasks.md
@@ -1,0 +1,41 @@
+# Tasks: Fix Flag Source Display
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-26
+
+## Format
+
+- `[P]` marks tasks that can run in parallel with adjacent `[P]` tasks.
+- Consecutive `[P]` tasks form a **parallel group** — `/sdd:implement` spawns them as concurrent subagents.
+- Tasks without `[P]` are **gates**: they start only after all prior tasks complete.
+- Two tasks that touch the same file are never both `[P]`.
+
+---
+
+## Phase 1: Core Implementation
+
+- [x] **T001** Decouple dot indicator from forced value in list-item — `libs/ngx-dev-toolbar/src/components/list-item/list-item.component.ts` | R001, R002, R003, R004, R007, NFR001, NFR002
+  - **Do**:
+    1. Add a `protected sourceValue = computed(...)` that returns `originalValue()` when `isForced() && originalValue() !== undefined`, else `currentValue()`.
+    2. In the template, change the dot bindings from `[class.dot-indicator--on]="currentValue()"` / `[class.dot-indicator--off]="!currentValue()"` to `sourceValue()` / `!sourceValue()`. Leave `dot-indicator--forced` and `list-item--forced` (row tint) bound to `isForced()`.
+    3. Update `tooltipText` computed: when `isForced() && originalValue() !== undefined && originalValue() !== currentValue()` → `"Server: <originalState> · Forced: <currentState>"`; when forced and values match → `"Currently <state>"`; else → `"Currently <state>"` (existing behaviour).
+    4. Update `statusAriaLabel` computed to announce the **source** value plus `, forced` qualifier when `isForced()` is true (e.g., `"disabled, forced"` for the divergent case where source = disabled, forced = enabled).
+  - **Verify**: `nx test ngx-dev-toolbar` passes; visually, a forced-on flag whose source value is `false` renders a red ring (off style) with amber row tint and the divergent tooltip.
+  - **Leverage**: existing `tooltipText` and `statusAriaLabel` computeds in this same file — keep their pure/signal style and only widen the branches.
+
+- [x] **T002** [P] Lock new dot semantics with unit tests *(depends on T001)* — `libs/ngx-dev-toolbar/src/components/list-item/list-item.component.spec.ts` | R001, R002, R003, R004, R007
+  - **Do**: Add three Jest cases against `ToolbarListItemComponent`:
+    1. *Forced + diverging source*: `isForced=true`, `originalValue=false`, `currentValue=true` → host element has class `dot-indicator--off` (NOT `--on`), `dot-indicator--forced` is present, the dot's `title` matches `/Server:.*disabled.*Forced:.*enabled/`, `aria-label` ends with `, forced`.
+    2. *Forced + matching source*: `isForced=true`, `originalValue=true`, `currentValue=true` → host has `dot-indicator--on` and `dot-indicator--forced`, `title` is `Currently enabled`, `aria-label` is `enabled, forced`.
+    3. *Non-forced regression guard*: `isForced=false`, `originalValue=undefined`, `currentValue=true` → host has `dot-indicator--on`, no `--forced`, `title` is `Currently enabled`.
+    4. *Defensive: forced with undefined originalValue* → falls back to `currentValue` so the dot still renders deterministically (e.g., `currentValue=true` → `--on`).
+  - **Verify**: `nx test ngx-dev-toolbar --testPathPattern=list-item` passes; all four cases green.
+  - **Leverage**: existing test setup in `list-item.component.spec.ts` — reuse its `TestBed.createComponent` + `componentRef.setInput` pattern.
+
+- [x] **T003** [P] Verify `Apply to source` button gating across all three tools *(depends on T001)* — verification only, no code change expected | R005, R006, R008
+  - **Do**: Open `feature-flags-tool.component.{ts,html}`, `permissions-tool.component.{ts,html}`, and `app-features-tool.component.{ts,html}`. For each, confirm that:
+    1. The component computes a `hasApplyCallback()` (or equivalent) signal driven by the public service's `setApplyToSource` registration state.
+    2. The `<ndt-list-item>` template binding is `[showApply]="hasApplyCallback()"` (NOT a hardcoded `true`).
+    3. The list-item template gates render with `@if (showApply() && isForced())` — already in place per `list-item.component.ts:61`.
+    4. If any of the three tools is missing the `[showApply]` binding or the `hasApplyCallback` plumbing, add it following the pattern from whichever tool already has it correctly wired.
+  - **Verify**: A consumer that does NOT call `service.setApplyToSource(...)` and forces a value sees no apply button on any of the three tool lists; one that does call it sees the button only on forced rows. Existing tool component specs (`feature-flags-tool.component.spec.ts`, `permissions-tool.component.spec.ts`, `app-features-tool.component.spec.ts`) still pass.
+  - **Leverage**: whichever of the three tools already has the correct pattern serves as the reference for the others if a fix is needed.


### PR DESCRIPTION
## Summary

- The list-item dot indicator now reflects the value the source of truth (server, LaunchDarkly, etc.) reported, not the developer's override. The amber row tint and "forced" aria qualifier still convey that the item is forced.
- Tooltip wording adopts `Server: X · Forced: Y` when the source and forced values diverge; falls through to `Currently X` otherwise.
- Decouples the dot color from `currentValue` so developers can see at a glance both what production says and what they've forced.

## Why

Spec 020 calls out that developers couldn't tell at a glance what production was actually returning when they had a value forced — the dot was always echoing the override. Decoupling the dot from `currentValue` lets both pieces of information surface in one place.

## Changes

- `list-item.component.ts`: new `sourceValue` computed; dot bindings switched from `currentValue()` to `sourceValue()`; `tooltipText` and `statusAriaLabel` updated to surface source-vs-forced semantics.
- `list-item.component.spec.ts`: 4 new Jest cases covering forced+diverging, forced+matching, non-forced regression guard, and defensive `originalValue=undefined` fallback.
- Adds `specs/020-fix-flag-source-display/` with the spec, plan, tasks, and SDD context for future drift detection.

## Already in place from prior work (verified, no change needed)

- `originalValue` input on `ndt-list-item`
- `[showApply]="hasApplyCallback()"` wired across feature-flags / permissions / app-features tools
- Internal services exposing `hasApplyCallback`

## Test plan

- [x] `nx test ngx-dev-toolbar` — 395/395 passing (4 new tests under `source-value dot indicator`)
- [x] `nx affected -t lint,test,build` — green for ngx-dev-toolbar lib + demo + docs
- [ ] Visual: force a flag whose source is `false` to `true` → dot renders red ring (off), row has amber tint, tooltip reads `Server: disabled · Forced: enabled`
- [ ] Visual: force a flag whose source is already `true` to `true` → dot renders filled green, row has amber tint, tooltip reads `Currently enabled`
- [ ] Visual: don't force a flag → dot tracks source value, no amber tint (regression guard)