### PR TITLE
feat(toolbar): stream-runner chaining context + mock-data live mirror

### DIFF
--- a/apps/docs/src/content/docs/guides/custom-tool.mdx
+++ b/apps/docs/src/content/docs/guides/custom-tool.mdx
@@ -240,6 +240,126 @@ export class MultiStepToolComponent {
 - **`ngtStep`** — Structural directive marking each step template
 - **`stepTitle`** — Optional title shown in the header for each step
 
+## Streaming Runner
+
+Reach for `<ndt-stream-runner>` when a tool kicks off a long-running, multi-entity
+creation flow and the user benefits from per-step, per-item progress — for example,
+"generate 50 invoices across 5 entity types" or "seed 100 users, then 500 posts,
+then 1500 comments". The multi-step pattern above is the right call when each view
+is a distinct UI; the streaming runner is the right call when the work itself is
+the UI: a sequence of steps, each producing N items, each item flushed to the view
+as it resolves.
+
+### `StreamStep<T>`
+
+A `StreamStep<T>` describes one phase of the run. The required fields are
+`label: string` (shown in the header), `total: number` (how many items this step
+produces), and `runItem: (index: number, ctx: StreamRunContext) => Promise<T>`
+(invoked once per item; whatever it resolves to is what consumers see). Optional
+fields tune the presentation: `verbActive` and `verbDone` swap the default
+"Creating…" / "Created" verbs; `badge`, `description`, and `link` decorate the
+step header; `describe` and `detail` format each item's primary label and
+secondary line; `placeholderDetail` is shown while an item is still pending.
+
+### Anatomy of a rendered step
+
+Every visible part of a step row comes from a string field on `StreamStep<T>`.
+The runner renders those strings through Angular interpolation, so HTML in the
+returned values is **escaped** — the customization story is "compose the right
+strings and let the runner lay them out", not "return markup". Use `link` to
+turn the title into an anchor; that's the only structural decoration available
+per item.
+
+```ts
+import { StreamStep } from 'ngx-dev-toolbar';
+
+interface User {
+  id: string;
+  name: string;
+  role: 'admin' | 'member';
+}
+
+const usersStep: StreamStep<User> = {
+  // Step header (shown above the per-item list)
+  label: 'Users',                      // "5 users" / "3 of 5 users…"
+  badge: 'USER',                       // small chip rendered next to the header
+  description: 'Active accounts in '
+    + 'various activation states.',    // sub-description under the header
+  total: 5,
+  verbActive: 'Provisioning',          // shown while the step is running
+  verbDone: 'Provisioned',             // shown after the step completes
+
+  // Per-item callback (drives both the data and the rendered row)
+  runItem: async (i) => {
+    await new Promise(r => setTimeout(r, 200));
+    return {
+      id: `user-${i + 1}`,
+      name: `User ${i + 1}`,
+      role: i === 0 ? 'admin' : 'member',
+    };
+  },
+
+  // Visible parts of each item, all built from the resolved value
+  describe: (u) => u.name,             // primary title text
+  detail: (u) => `id ${u.id} · ${u.role}`, // secondary line below the title
+  link: (u) => `/users/${u.id}`,       // makes the title an anchor with a → arrow
+  placeholderDetail: 'Provisioning…',  // detail line shown while an item is pending
+};
+```
+
+What each field controls in the rendered row:
+
+- **Step header** — `verbActive` / `verbDone` flip the verb based on status; `label`
+  appears next to the count (e.g. `Provisioned 5 users`); `badge` is a small chip;
+  `description` is a single muted line below the header.
+- **Per-item title** — `describe(value)` provides the title text. When `link(value)`
+  is set, the title is wrapped in an anchor pointing at that URL with a trailing
+  `→` arrow.
+- **Per-item detail** — `detail(value)` produces the secondary line shown beneath
+  the title once the item resolves. While the item is still pending, `placeholderDetail`
+  is shown instead (default: `"Working…"`).
+- **Per-item icon** — automatically managed by the runner based on item status
+  (`queued` / `running` / `done` / `error`); not consumer-controllable.
+
+For richer formatting (badges per item, multi-line details, inline icons), compose
+the strings yourself — e.g. `detail: (u) => \`\${u.role.toUpperCase()} · last seen \${u.lastSeen}\``.
+Returning HTML or Angular templates is not currently supported.
+
+### `StreamRunOptions`
+
+A run is configured with `StreamRunOptions`: `title` (the run header),
+`preamble` (a short blurb shown above the first step), `steps` (an ordered
+array of `StreamStep`s), and `pacing` (controls inter-item delay so the stream
+feels live rather than instant).
+
+### Chaining steps with `ctx.prior(...)`
+
+`runItem` receives a `StreamRunContext` as its second argument. Call
+`ctx.prior(stepIndexOrLabel)` to read the resolved values from any earlier step
+in the same run — that's how later steps reference entities produced upstream.
+
+```ts
+import { StreamStep, StreamRunContext } from 'ngx-dev-toolbar';
+
+const customersStep: StreamStep<{ id: string }> = {
+  label: 'Customers',
+  total: 5,
+  runItem: async (i) => ({ id: `customer-${i + 1}` }),
+};
+
+const invoicesStep: StreamStep<{ id: string; customerId: string }> = {
+  label: 'Invoices',
+  total: 10,
+  runItem: async (i, ctx) => {
+    const customers = ctx.prior('Customers') as readonly { id: string }[];
+    const customer = customers[i % customers.length];
+    return { id: `invoice-${i + 1}`, customerId: customer.id };
+  },
+};
+```
+
+See the live demo at `/stream-runner` in the demo app for a runnable Authors → Posts → Comments example.
+
 ## Styling
 
 Use the toolbar's design tokens for consistent styling. All tokens use the `--ndt-` prefix:

--- a/apps/docs/src/content/docs/guides/custom-tool.mdx
+++ b/apps/docs/src/content/docs/guides/custom-tool.mdx
@@ -322,7 +322,12 @@ What each field controls in the rendered row:
   (`queued` / `running` / `done` / `error`); not consumer-controllable.
 
 For richer formatting (badges per item, multi-line details, inline icons), compose
-the strings yourself — e.g. `detail: (u) => \`\${u.role.toUpperCase()} · last seen \${u.lastSeen}\``.
+the strings yourself — e.g.
+
+```ts
+detail: (u) => `${u.role.toUpperCase()} · last seen ${u.lastSeen}`
+```
+
 Returning HTML or Angular templates is not currently supported.
 
 ### `StreamRunOptions`

--- a/apps/ngx-dev-toolbar-demo/src/app/app.routes.ts
+++ b/apps/ngx-dev-toolbar-demo/src/app/app.routes.ts
@@ -41,4 +41,11 @@ export const appRoutes: Route[] = [
         (m) => m.CustomToolDemoComponent
       ),
   },
+  {
+    path: 'stream-runner',
+    loadComponent: () =>
+      import('./components/stream-runner-demo/stream-runner-demo.component').then(
+        (m) => m.StreamRunnerDemoComponent
+      ),
+  },
 ];

--- a/apps/ngx-dev-toolbar-demo/src/app/components/custom-tool-demo/custom-tool-demo.component.ts
+++ b/apps/ngx-dev-toolbar-demo/src/app/components/custom-tool-demo/custom-tool-demo.component.ts
@@ -1,4 +1,7 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Signal, inject } from '@angular/core';
+import { MockDataStoreService } from '../custom-tool/mock-data-store.service';
+
+type EntityLike = { id: string; name: string };
 
 @Component({
   selector: 'app-custom-tool-demo',
@@ -8,41 +11,35 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
       <div class="demo-header">
         <h2>Custom Tool</h2>
         <p class="demo-description">
-          A demo toolbar tool showcasing the <code>ndt-tabs</code> component with Finder and Maker tabs.
-          Open the <strong>puzzle icon</strong> in the toolbar below to try it.
+          This page mirrors the entities created by the toolbar's <strong>Mock Data</strong> tool.
+          Open the puzzle icon in the toolbar below, run a CREATE bundle, and watch the cards populate live.
         </p>
       </div>
 
       <div class="demo-card-grid">
-        <div class="demo-card">
-          <div class="card-header">
-            <h3>Finder Tab</h3>
+        @for (card of cards; track card.label) {
+          @let items = card.entities();
+          <div class="demo-card" [class.demo-card--empty]="items.length === 0">
+            <div class="card-header">
+              <h3>{{ card.label }}</h3>
+              <span class="card-count">{{ items.length }}</span>
+            </div>
+            @if (items.length > 0) {
+              <ul class="card-preview">
+                @for (item of items.slice(-5); track item.id) {
+                  <li class="preview-item">
+                    <code class="preview-id">{{ item.id }}</code>
+                    <span class="preview-name">{{ item.name }}</span>
+                  </li>
+                }
+              </ul>
+            } @else {
+              <p class="card-empty">
+                Run the toolbar's Mock Data tool to seed <code>{{ card.label.toLowerCase() }}</code>.
+              </p>
+            }
           </div>
-          <p class="card-description">
-            Search for application routes or DOM elements. Select a type from the dropdown
-            and click Find to see mock results.
-          </p>
-          <div class="card-preview">
-            <div class="preview-item"><code>/dashboard</code> — DashboardComponent</div>
-            <div class="preview-item"><code>/users/:id</code> — UserDetailComponent</div>
-            <div class="preview-item"><code>&lt;app-header&gt;</code> — 1 instance</div>
-          </div>
-        </div>
-
-        <div class="demo-card">
-          <div class="card-header">
-            <h3>Maker Tab</h3>
-          </div>
-          <p class="card-description">
-            Generate mock data entries on the fly. Select User, Order, or Product
-            and click Create to build sample records.
-          </p>
-          <div class="card-preview">
-            <div class="preview-item preview-item--green">Mock User #1 — 10:42:15 AM</div>
-            <div class="preview-item preview-item--green">Mock Order #2 — 10:42:18 AM</div>
-            <div class="preview-item preview-item--green">Mock Product #3 — 10:42:21 AM</div>
-          </div>
-        </div>
+        }
       </div>
     </section>
   `,
@@ -92,11 +89,24 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
       border-radius: var(--demo-radius, 8px);
       padding: 1.25rem;
       box-shadow: var(--demo-shadow, 0 1px 3px rgba(0, 0, 0, 0.1));
-      transition: border-color 0.2s;
+      transition: border-color 0.2s, opacity 0.2s;
     }
 
     .demo-card:hover {
       border-color: var(--demo-primary, #6366f1);
+    }
+
+    .demo-card--empty {
+      opacity: 0.7;
+      background: var(--demo-bg, #f8fafc);
+    }
+
+    .card-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.5rem;
+      margin-bottom: 0.75rem;
     }
 
     .card-header h3 {
@@ -106,35 +116,67 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
       color: var(--demo-text, #1e293b);
     }
 
-    .card-description {
-      margin: 0.5rem 0 1rem 0;
-      font-size: 0.875rem;
+    .card-count {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.8125rem;
       color: var(--demo-text-muted, #64748b);
-      line-height: 1.5;
+      background: var(--demo-bg, #f1f5f9);
+      padding: 0.125rem 0.5rem;
+      border-radius: 999px;
+      min-width: 1.5rem;
+      text-align: center;
     }
 
     .card-preview {
+      list-style: none;
+      margin: 0;
+      padding: 0;
       display: flex;
       flex-direction: column;
       gap: 0.375rem;
-      padding: 0.75rem;
-      background: var(--demo-bg, #f8fafc);
-      border-radius: 6px;
     }
 
     .preview-item {
+      display: flex;
+      align-items: baseline;
+      gap: 0.5rem;
       padding: 0.375rem 0.5rem;
-      background: white;
+      background: var(--demo-bg, #f8fafc);
       border-radius: 4px;
       font-size: 0.8125rem;
       color: var(--demo-text, #1e293b);
+      overflow: hidden;
+      white-space: nowrap;
     }
 
-    .preview-item code {
+    .preview-id {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
       font-size: 0.75rem;
+      color: var(--demo-text-muted, #64748b);
+      flex-shrink: 0;
+    }
+
+    .preview-name {
+      color: var(--demo-text, #1e293b);
+      font-weight: 400;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .card-empty {
+      margin: 0;
+      font-size: 0.8125rem;
+      color: var(--demo-text-muted, #64748b);
+      font-style: italic;
+      line-height: 1.5;
+    }
+
+    .card-empty code {
+      font-style: normal;
       background: var(--demo-bg, #f1f5f9);
       padding: 0.0625rem 0.25rem;
       border-radius: 3px;
+      font-size: 0.75rem;
     }
 
     @media (max-width: 640px) {
@@ -145,4 +187,30 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   `],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CustomToolDemoComponent {}
+export class CustomToolDemoComponent {
+  private readonly store = inject(MockDataStoreService);
+
+  protected readonly LABELS: readonly string[] = [
+    'Customers',
+    'Invoices',
+    'Subscriptions',
+    'Line items',
+    'Payment methods',
+    'Categories',
+    'Products',
+    'Variants',
+    'Inventory',
+    'Suppliers',
+    'Users',
+    'Sessions',
+    'Profiles',
+    'Preferences',
+    'Invitations',
+  ];
+
+  protected readonly cards: { label: string; entities: Signal<readonly EntityLike[]> }[] =
+    this.LABELS.map((label) => ({
+      label,
+      entities: this.store.entitiesSignal<EntityLike>(label),
+    }));
+}

--- a/apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/custom-tool.component.ts
+++ b/apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/custom-tool.component.ts
@@ -66,8 +66,6 @@ function makeEntityStep(
 ): StreamStep<MockEntity> {
   const singular = nounSingular(label).toLowerCase();
   const titleCaseSingular = nounSingular(label);
-  // Per-step buffer; fresh per call because buildSteps is invoked on each run.
-  const buffer: MockEntity[] = [];
   return {
     label,
     badge,
@@ -84,10 +82,10 @@ function makeEntityStep(
         id: `${badge.toLowerCase()}-${randomId()}`,
         name: `${titleCaseSingular} ${i + 1}`,
       };
-      buffer.push(entity);
-      if (i === count - 1) {
-        store.addBatch(label, buffer);
-      }
+      // Per-item flush: each successful entity is written immediately so that
+      // a downstream item failure or run cancellation can never lose earlier
+      // successes. Angular signals coalesce writes within a microtask.
+      store.addBatch(label, [entity]);
       return entity;
     },
     link: (item) => `/${prefix}/${item.id}`,
@@ -103,87 +101,81 @@ const BUNDLES: BundleDefinition[] = [
     label: 'Billing data',
     preamble: 'Customers, invoices, subscriptions, line items, payment methods.',
     typeNames: 'customers, invoices, subscriptions, line items, payment methods',
-    buildSteps: (n, store) => {
-      const invoiceBuffer: InvoiceEntity[] = [];
-      return [
-        makeEntityStep(
-          {
-            label: 'Customers',
-            badge: 'CUSTOMER',
-            prefix: 'billing/customers',
-            count: n,
-            description: 'Active accounts with valid payment methods on file.',
-          },
-          store,
-        ),
+    buildSteps: (n, store) => [
+      makeEntityStep(
         {
-          label: 'Invoices',
-          badge: 'INVOICE',
-          total: n,
-          description: 'A mix of paid, pending, and overdue invoices.',
-          runItem: async (i, ctx) => {
-            await wait(2000 + Math.random() * 3000);
-            if (Math.random() < 0.07) {
-              throw new Error(`Could not save invoice ${i + 1}`);
-            }
-            const customers = ctx.prior('Customers') as readonly MockEntity[];
-            const customer = customers.length > 0 ? customers[i % customers.length] : null;
-            const invoice: InvoiceEntity = {
-              id: `invoice-${randomId()}`,
-              name: `Invoice ${i + 1}`,
-              customerId: customer?.id ?? null,
-            };
-            invoiceBuffer.push(invoice);
-            if (i === n - 1) {
-              store.addBatch('Invoices', invoiceBuffer);
-            }
-            return invoice;
-          },
-          link: (item) => {
-            const customerId = (item as InvoiceEntity).customerId;
-            return customerId
-              ? `/billing/customers/${customerId}/invoices/${item.id}`
-              : `/billing/invoices/${item.id}`;
-          },
-          describe: (item) => item.name,
-          detail: (item) => {
-            const cid = (item as InvoiceEntity).customerId;
-            return cid ? `id ${item.id} · for customer ${cid}` : `id ${item.id} · no customer`;
-          },
-          placeholderDetail: 'Generating invoice record…',
+          label: 'Customers',
+          badge: 'CUSTOMER',
+          prefix: 'billing/customers',
+          count: n,
+          description: 'Active accounts with valid payment methods on file.',
         },
-        makeEntityStep(
-          {
-            label: 'Subscriptions',
-            badge: 'SUBSCRIPTION',
-            prefix: 'billing/subscriptions',
-            count: n,
-            description: 'Standard, pro, and enterprise tier subscriptions.',
-          },
-          store,
-        ),
-        makeEntityStep(
-          {
-            label: 'Line items',
-            badge: 'LINEITEM',
-            prefix: 'billing/line-items',
-            count: n,
-            description: 'Line items linked to the generated invoices.',
-          },
-          store,
-        ),
-        makeEntityStep(
-          {
-            label: 'Payment methods',
-            badge: 'PAYMENT',
-            prefix: 'billing/payment-methods',
-            count: n,
-            description: 'Cards, ACH transfers, and digital wallets for checkout testing.',
-          },
-          store,
-        ),
-      ];
-    },
+        store,
+      ),
+      {
+        label: 'Invoices',
+        badge: 'INVOICE',
+        total: n,
+        description: 'A mix of paid, pending, and overdue invoices.',
+        runItem: async (i, ctx) => {
+          await wait(2000 + Math.random() * 3000);
+          if (Math.random() < 0.07) {
+            throw new Error(`Could not save invoice ${i + 1}`);
+          }
+          const customers = ctx.prior('Customers') as readonly MockEntity[];
+          const customer = customers.length > 0 ? customers[i % customers.length] : null;
+          const invoice: InvoiceEntity = {
+            id: `invoice-${randomId()}`,
+            name: `Invoice ${i + 1}`,
+            customerId: customer?.id ?? null,
+          };
+          store.addBatch('Invoices', [invoice]);
+          return invoice;
+        },
+        link: (item) => {
+          const customerId = (item as InvoiceEntity).customerId;
+          return customerId
+            ? `/billing/customers/${customerId}/invoices/${item.id}`
+            : `/billing/invoices/${item.id}`;
+        },
+        describe: (item) => item.name,
+        detail: (item) => {
+          const cid = (item as InvoiceEntity).customerId;
+          return cid ? `id ${item.id} · for customer ${cid}` : `id ${item.id} · no customer`;
+        },
+        placeholderDetail: 'Generating invoice record…',
+      },
+      makeEntityStep(
+        {
+          label: 'Subscriptions',
+          badge: 'SUBSCRIPTION',
+          prefix: 'billing/subscriptions',
+          count: n,
+          description: 'Standard, pro, and enterprise tier subscriptions.',
+        },
+        store,
+      ),
+      makeEntityStep(
+        {
+          label: 'Line items',
+          badge: 'LINEITEM',
+          prefix: 'billing/line-items',
+          count: n,
+          description: 'Line items linked to the generated invoices.',
+        },
+        store,
+      ),
+      makeEntityStep(
+        {
+          label: 'Payment methods',
+          badge: 'PAYMENT',
+          prefix: 'billing/payment-methods',
+          count: n,
+          description: 'Cards, ACH transfers, and digital wallets for checkout testing.',
+        },
+        store,
+      ),
+    ],
   },
   {
     id: 'retail',

--- a/apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/custom-tool.component.ts
+++ b/apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/custom-tool.component.ts
@@ -17,12 +17,17 @@ import {
   ToolbarWindowOptions,
   wait,
 } from 'ngx-dev-toolbar';
+import { MockDataStoreService } from './mock-data-store.service';
 
 // ─── Mock data shapes ────────────────────────────────────────────────────
 
 interface MockEntity {
   id: string;
   name: string;
+}
+
+interface InvoiceEntity extends MockEntity {
+  customerId: string | null;
 }
 
 interface RouteEntity {
@@ -44,7 +49,7 @@ interface BundleDefinition {
   label: string;
   preamble: string;
   typeNames: string;
-  buildSteps: (count: number) => StreamStep<MockEntity>[];
+  buildSteps: (count: number, store: MockDataStoreService) => StreamStep<MockEntity>[];
 }
 
 interface EntityStepConfig {
@@ -55,15 +60,14 @@ interface EntityStepConfig {
   description: string;
 }
 
-function makeEntityStep({
-  label,
-  badge,
-  prefix,
-  count,
-  description,
-}: EntityStepConfig): StreamStep<MockEntity> {
+function makeEntityStep(
+  { label, badge, prefix, count, description }: EntityStepConfig,
+  store: MockDataStoreService,
+): StreamStep<MockEntity> {
   const singular = nounSingular(label).toLowerCase();
   const titleCaseSingular = nounSingular(label);
+  // Per-step buffer; fresh per call because buildSteps is invoked on each run.
+  const buffer: MockEntity[] = [];
   return {
     label,
     badge,
@@ -76,10 +80,15 @@ function makeEntityStep({
       if (Math.random() < 0.07) {
         throw new Error(`Could not save ${singular} ${i + 1}`);
       }
-      return {
+      const entity: MockEntity = {
         id: `${badge.toLowerCase()}-${randomId()}`,
         name: `${titleCaseSingular} ${i + 1}`,
       };
+      buffer.push(entity);
+      if (i === count - 1) {
+        store.addBatch(label, buffer);
+      }
+      return entity;
     },
     link: (item) => `/${prefix}/${item.id}`,
     describe: (item) => item.name,
@@ -94,85 +103,144 @@ const BUNDLES: BundleDefinition[] = [
     label: 'Billing data',
     preamble: 'Customers, invoices, subscriptions, line items, payment methods.',
     typeNames: 'customers, invoices, subscriptions, line items, payment methods',
-    buildSteps: (n) => [
-      makeEntityStep({
-        label: 'Customers',
-        badge: 'CUSTOMER',
-        prefix: 'billing/customers',
-        count: n,
-        description: 'Active accounts with valid payment methods on file.',
-      }),
-      makeEntityStep({
-        label: 'Invoices',
-        badge: 'INVOICE',
-        prefix: 'billing/invoices',
-        count: n,
-        description: 'A mix of paid, pending, and overdue invoices.',
-      }),
-      makeEntityStep({
-        label: 'Subscriptions',
-        badge: 'SUBSCRIPTION',
-        prefix: 'billing/subscriptions',
-        count: n,
-        description: 'Standard, pro, and enterprise tier subscriptions.',
-      }),
-      makeEntityStep({
-        label: 'Line items',
-        badge: 'LINEITEM',
-        prefix: 'billing/line-items',
-        count: n,
-        description: 'Line items linked to the generated invoices.',
-      }),
-      makeEntityStep({
-        label: 'Payment methods',
-        badge: 'PAYMENT',
-        prefix: 'billing/payment-methods',
-        count: n,
-        description: 'Cards, ACH transfers, and digital wallets for checkout testing.',
-      }),
-    ],
+    buildSteps: (n, store) => {
+      const invoiceBuffer: InvoiceEntity[] = [];
+      return [
+        makeEntityStep(
+          {
+            label: 'Customers',
+            badge: 'CUSTOMER',
+            prefix: 'billing/customers',
+            count: n,
+            description: 'Active accounts with valid payment methods on file.',
+          },
+          store,
+        ),
+        {
+          label: 'Invoices',
+          badge: 'INVOICE',
+          total: n,
+          description: 'A mix of paid, pending, and overdue invoices.',
+          runItem: async (i, ctx) => {
+            await wait(2000 + Math.random() * 3000);
+            if (Math.random() < 0.07) {
+              throw new Error(`Could not save invoice ${i + 1}`);
+            }
+            const customers = ctx.prior('Customers') as readonly MockEntity[];
+            const customer = customers.length > 0 ? customers[i % customers.length] : null;
+            const invoice: InvoiceEntity = {
+              id: `invoice-${randomId()}`,
+              name: `Invoice ${i + 1}`,
+              customerId: customer?.id ?? null,
+            };
+            invoiceBuffer.push(invoice);
+            if (i === n - 1) {
+              store.addBatch('Invoices', invoiceBuffer);
+            }
+            return invoice;
+          },
+          link: (item) => {
+            const customerId = (item as InvoiceEntity).customerId;
+            return customerId
+              ? `/billing/customers/${customerId}/invoices/${item.id}`
+              : `/billing/invoices/${item.id}`;
+          },
+          describe: (item) => item.name,
+          detail: (item) => {
+            const cid = (item as InvoiceEntity).customerId;
+            return cid ? `id ${item.id} · for customer ${cid}` : `id ${item.id} · no customer`;
+          },
+          placeholderDetail: 'Generating invoice record…',
+        },
+        makeEntityStep(
+          {
+            label: 'Subscriptions',
+            badge: 'SUBSCRIPTION',
+            prefix: 'billing/subscriptions',
+            count: n,
+            description: 'Standard, pro, and enterprise tier subscriptions.',
+          },
+          store,
+        ),
+        makeEntityStep(
+          {
+            label: 'Line items',
+            badge: 'LINEITEM',
+            prefix: 'billing/line-items',
+            count: n,
+            description: 'Line items linked to the generated invoices.',
+          },
+          store,
+        ),
+        makeEntityStep(
+          {
+            label: 'Payment methods',
+            badge: 'PAYMENT',
+            prefix: 'billing/payment-methods',
+            count: n,
+            description: 'Cards, ACH transfers, and digital wallets for checkout testing.',
+          },
+          store,
+        ),
+      ];
+    },
   },
   {
     id: 'retail',
     label: 'Retail catalog',
     preamble: 'Categories, products, variants, inventory, suppliers.',
     typeNames: 'categories, products, variants, inventory, suppliers',
-    buildSteps: (n) => [
-      makeEntityStep({
-        label: 'Categories',
-        badge: 'CATEGORY',
-        prefix: 'retail/categories',
-        count: n,
-        description: 'Top-level taxonomy that organizes the catalog.',
-      }),
-      makeEntityStep({
-        label: 'Products',
-        badge: 'PRODUCT',
-        prefix: 'retail/products',
-        count: n,
-        description: 'SKUs distributed across the generated categories.',
-      }),
-      makeEntityStep({
-        label: 'Variants',
-        badge: 'VARIANT',
-        prefix: 'retail/variants',
-        count: n,
-        description: 'Size and color variants attached to each product.',
-      }),
-      makeEntityStep({
-        label: 'Inventory',
-        badge: 'INVENTORY',
-        prefix: 'retail/inventory',
-        count: n,
-        description: 'Stock levels with mock warehouse locations.',
-      }),
-      makeEntityStep({
-        label: 'Suppliers',
-        badge: 'SUPPLIER',
-        prefix: 'retail/suppliers',
-        count: n,
-        description: 'Vendor records linked to a subset of products.',
-      }),
+    buildSteps: (n, store) => [
+      makeEntityStep(
+        {
+          label: 'Categories',
+          badge: 'CATEGORY',
+          prefix: 'retail/categories',
+          count: n,
+          description: 'Top-level taxonomy that organizes the catalog.',
+        },
+        store,
+      ),
+      makeEntityStep(
+        {
+          label: 'Products',
+          badge: 'PRODUCT',
+          prefix: 'retail/products',
+          count: n,
+          description: 'SKUs distributed across the generated categories.',
+        },
+        store,
+      ),
+      makeEntityStep(
+        {
+          label: 'Variants',
+          badge: 'VARIANT',
+          prefix: 'retail/variants',
+          count: n,
+          description: 'Size and color variants attached to each product.',
+        },
+        store,
+      ),
+      makeEntityStep(
+        {
+          label: 'Inventory',
+          badge: 'INVENTORY',
+          prefix: 'retail/inventory',
+          count: n,
+          description: 'Stock levels with mock warehouse locations.',
+        },
+        store,
+      ),
+      makeEntityStep(
+        {
+          label: 'Suppliers',
+          badge: 'SUPPLIER',
+          prefix: 'retail/suppliers',
+          count: n,
+          description: 'Vendor records linked to a subset of products.',
+        },
+        store,
+      ),
     ],
   },
   {
@@ -180,42 +248,57 @@ const BUNDLES: BundleDefinition[] = [
     label: 'User onboarding',
     preamble: 'Users, sessions, profiles, preferences, invitations.',
     typeNames: 'users, sessions, profiles, preferences, invitations',
-    buildSteps: (n) => [
-      makeEntityStep({
-        label: 'Users',
-        badge: 'USER',
-        prefix: 'users',
-        count: n,
-        description: 'New accounts in various activation states.',
-      }),
-      makeEntityStep({
-        label: 'Sessions',
-        badge: 'SESSION',
-        prefix: 'sessions',
-        count: n,
-        description: 'Active and expired login sessions across devices.',
-      }),
-      makeEntityStep({
-        label: 'Profiles',
-        badge: 'PROFILE',
-        prefix: 'profiles',
-        count: n,
-        description: 'Avatars, bios, and preferences set for each user.',
-      }),
-      makeEntityStep({
-        label: 'Preferences',
-        badge: 'PREFERENCE',
-        prefix: 'preferences',
-        count: n,
-        description: 'Notification, locale, and display settings per profile.',
-      }),
-      makeEntityStep({
-        label: 'Invitations',
-        badge: 'INVITE',
-        prefix: 'invites',
-        count: n,
-        description: 'Pending invites in different stages of acceptance.',
-      }),
+    buildSteps: (n, store) => [
+      makeEntityStep(
+        {
+          label: 'Users',
+          badge: 'USER',
+          prefix: 'users',
+          count: n,
+          description: 'New accounts in various activation states.',
+        },
+        store,
+      ),
+      makeEntityStep(
+        {
+          label: 'Sessions',
+          badge: 'SESSION',
+          prefix: 'sessions',
+          count: n,
+          description: 'Active and expired login sessions across devices.',
+        },
+        store,
+      ),
+      makeEntityStep(
+        {
+          label: 'Profiles',
+          badge: 'PROFILE',
+          prefix: 'profiles',
+          count: n,
+          description: 'Avatars, bios, and preferences set for each user.',
+        },
+        store,
+      ),
+      makeEntityStep(
+        {
+          label: 'Preferences',
+          badge: 'PREFERENCE',
+          prefix: 'preferences',
+          count: n,
+          description: 'Notification, locale, and display settings per profile.',
+        },
+        store,
+      ),
+      makeEntityStep(
+        {
+          label: 'Invitations',
+          badge: 'INVITE',
+          prefix: 'invites',
+          count: n,
+          description: 'Pending invites in different stages of acceptance.',
+        },
+        store,
+      ),
     ],
   },
 ];
@@ -300,36 +383,6 @@ interface ToolAction {
   /** Run options builder (for direct-run actions). */
   buildOptions?: () => StreamRunOptions;
 }
-
-const ACTIONS: ToolAction[] = [
-  ...BUNDLES.map((b): ToolAction => ({
-    id: `create-${b.id}`,
-    section: 'create',
-    glyph: 'sparkle',
-    label: b.label,
-    hint: '5 types',
-    flow: 'drill',
-    bundleId: b.id,
-  })),
-  {
-    id: 'find-routes',
-    section: 'find',
-    glyph: 'magnifier',
-    label: 'Routes',
-    hint: `${ROUTES.length} routes`,
-    flow: 'direct',
-    buildOptions: buildFindRoutesOptions,
-  },
-  {
-    id: 'find-elements',
-    section: 'find',
-    glyph: 'magnifier',
-    label: 'DOM elements',
-    hint: `${ELEMENTS.length} types`,
-    flow: 'direct',
-    buildOptions: buildFindElementsOptions,
-  },
-];
 
 // ─── Component ───────────────────────────────────────────────────────────
 
@@ -496,16 +549,139 @@ export class ToolbarCustomToolComponent {
 
   private readonly runner = viewChild<ToolbarStreamRunnerComponent>('runner');
   private readonly injector = inject(Injector);
+  private readonly store = inject(MockDataStoreService);
+
+  // ── Action catalog (instance-scoped so FIND builders can read the store) ─
+
+  private buildActions(): ToolAction[] {
+    return [
+      ...BUNDLES.map((b): ToolAction => ({
+        id: `create-${b.id}`,
+        section: 'create',
+        glyph: 'sparkle',
+        label: b.label,
+        hint: '5 types',
+        flow: 'drill',
+        bundleId: b.id,
+      })),
+      {
+        id: 'find-customers',
+        section: 'find',
+        glyph: 'magnifier',
+        label: 'Customers',
+        hint: 'from billing',
+        flow: 'direct',
+        buildOptions: () => this.buildFindCustomersOptions(),
+      },
+      {
+        id: 'find-categories',
+        section: 'find',
+        glyph: 'magnifier',
+        label: 'Categories',
+        hint: 'from retail',
+        flow: 'direct',
+        buildOptions: () => this.buildFindCategoriesOptions(),
+      },
+      {
+        id: 'find-users',
+        section: 'find',
+        glyph: 'magnifier',
+        label: 'Users',
+        hint: 'from onboarding',
+        flow: 'direct',
+        buildOptions: () => this.buildFindUsersOptions(),
+      },
+      {
+        id: 'find-routes',
+        section: 'find',
+        glyph: 'magnifier',
+        label: 'Routes',
+        hint: `${ROUTES.length} routes`,
+        flow: 'direct',
+        buildOptions: buildFindRoutesOptions,
+      },
+      {
+        id: 'find-elements',
+        section: 'find',
+        glyph: 'magnifier',
+        label: 'DOM elements',
+        hint: `${ELEMENTS.length} types`,
+        flow: 'direct',
+        buildOptions: buildFindElementsOptions,
+      },
+    ];
+  }
+
+  // ── FIND-from-store builders ──────────────────────────────────────────
+
+  private buildFindEntitiesOptions(
+    storeLabel: string,
+    title: string,
+    prefix: string,
+    seedHint: string,
+  ): StreamRunOptions {
+    const items = this.store.entities<MockEntity>(storeLabel);
+    const total = items.length;
+    return {
+      title,
+      preamble:
+        total === 0
+          ? `No ${storeLabel.toLowerCase()} yet — ${seedHint}`
+          : `${total} ${storeLabel.toLowerCase()} in the in-memory store.`,
+      steps: [{
+        label: storeLabel,
+        verbActive: 'Reading',
+        verbDone: 'Found',
+        total,
+        runItem: async (i) => {
+          await wait(120 + Math.random() * 280);
+          return this.store.entities<MockEntity>(storeLabel)[i];
+        },
+        link: (item) => `/${prefix}/${item.id}`,
+        describe: (item) => item.name,
+        detail: (item) => `id ${item.id}`,
+        placeholderDetail: 'Reading entity…',
+      }],
+      pacing: { stepGap: 0 },
+    };
+  }
+
+  private buildFindCustomersOptions(): StreamRunOptions {
+    return this.buildFindEntitiesOptions(
+      'Customers',
+      'Searching customers',
+      'billing/customers',
+      'run CREATE → Billing data to seed data.',
+    );
+  }
+
+  private buildFindCategoriesOptions(): StreamRunOptions {
+    return this.buildFindEntitiesOptions(
+      'Categories',
+      'Searching categories',
+      'retail/categories',
+      'run CREATE → Retail catalog to seed data.',
+    );
+  }
+
+  private buildFindUsersOptions(): StreamRunOptions {
+    return this.buildFindEntitiesOptions(
+      'Users',
+      'Searching users',
+      'users',
+      'run CREATE → User onboarding to seed data.',
+    );
+  }
 
   // ── Action lookup helpers ─────────────────────────────────────────────
 
   protected actionsBySection(section: ActionSection): ToolAction[] {
-    return ACTIONS.filter((a) => a.section === section);
+    return this.buildActions().filter((a) => a.section === section);
   }
 
   protected selectedAction(): ToolAction | null {
     const id = this.selectedActionId();
-    return id ? ACTIONS.find((a) => a.id === id) ?? null : null;
+    return id ? this.buildActions().find((a) => a.id === id) ?? null : null;
   }
 
   protected selectedBundle(): BundleDefinition | null {
@@ -596,7 +772,7 @@ export class ToolbarCustomToolComponent {
       return {
         title: `Generating ${bundle.label.toLowerCase()}`,
         preamble: bundle.preamble,
-        steps: bundle.buildSteps(this.count()),
+        steps: bundle.buildSteps(this.count(), this.store),
       };
     }
     return null;

--- a/apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/mock-data-store.service.ts
+++ b/apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/mock-data-store.service.ts
@@ -1,0 +1,57 @@
+/**
+ * Demo app's in-memory mirror of mock entities created by the toolbar's mock-data tool.
+ * Lives only in the demo application — not part of the ngx-dev-toolbar library.
+ */
+import { Injectable, Signal, computed, signal } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class MockDataStoreService {
+  private readonly state = signal<Map<string, unknown[]>>(new Map());
+
+  /**
+   * Append a batch of items to the array stored under `label`.
+   * Performs an immutable update: the previous array reference is not mutated.
+   */
+  addBatch(label: string, items: readonly unknown[]): void {
+    this.state.update((current) => {
+      const next = new Map(current);
+      const previous = current.get(label) ?? [];
+      next.set(label, [...previous, ...items]);
+      return next;
+    });
+  }
+
+  /**
+   * Synchronously read the current array for `label`, or an empty array if absent.
+   */
+  entities<T>(label: string): readonly T[] {
+    return (this.state().get(label) ?? []) as readonly T[];
+  }
+
+  /**
+   * Returns a computed signal that derives the array slice for `label` from the inner map.
+   */
+  entitiesSignal<T>(label: string): Signal<readonly T[]> {
+    return computed(() => (this.state().get(label) ?? []) as readonly T[]);
+  }
+
+  /**
+   * Remove a single label from the store, or clear all entries when `label` is omitted.
+   * Always replaces the inner map immutably.
+   */
+  clear(label?: string): void {
+    if (label === undefined) {
+      this.state.set(new Map());
+      return;
+    }
+
+    this.state.update((current) => {
+      if (!current.has(label)) {
+        return current;
+      }
+      const next = new Map(current);
+      next.delete(label);
+      return next;
+    });
+  }
+}

--- a/apps/ngx-dev-toolbar-demo/src/app/components/sidebar/sidebar.component.ts
+++ b/apps/ngx-dev-toolbar-demo/src/app/components/sidebar/sidebar.component.ts
@@ -275,6 +275,12 @@ export class SidebarComponent {
       path: '/custom-tool',
       icon: '<path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>',
     },
+    {
+      id: 'stream-runner',
+      label: 'Stream Runner',
+      path: '/stream-runner',
+      icon: '<path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>',
+    },
   ];
 
   private readonly forcedFlags = toSignal(this.flagsService.getForcedValues(), {

--- a/apps/ngx-dev-toolbar-demo/src/app/components/stream-runner-demo/stream-runner-demo.component.scss
+++ b/apps/ngx-dev-toolbar-demo/src/app/components/stream-runner-demo/stream-runner-demo.component.scss
@@ -1,0 +1,51 @@
+.showcase {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+.showcase-section {
+  background: var(--demo-card-bg, #ffffff);
+  border: 1px solid var(--demo-border, #e2e8f0);
+  border-radius: var(--demo-radius, 8px);
+  padding: 1.25rem 1.5rem;
+  box-shadow: var(--demo-shadow, 0 1px 3px rgba(0, 0, 0, 0.08));
+
+  > h2 {
+    margin: 0 0 0.5rem;
+    font-size: 1.125rem;
+    font-weight: 600;
+  }
+
+  > p {
+    margin: 0;
+    color: var(--demo-text-muted, #64748b);
+    line-height: 1.5;
+  }
+}
+
+.showcase-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+.showcase-runner {
+  display: block;
+  max-width: 720px;
+  padding: 1rem 0;
+}
+
+@media (max-width: 640px) {
+  .showcase {
+    padding: 1.25rem 1rem;
+  }
+
+  .showcase-runner {
+    max-width: 100%;
+  }
+}

--- a/apps/ngx-dev-toolbar-demo/src/app/components/stream-runner-demo/stream-runner-demo.component.ts
+++ b/apps/ngx-dev-toolbar-demo/src/app/components/stream-runner-demo/stream-runner-demo.component.ts
@@ -1,0 +1,159 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  viewChild,
+} from '@angular/core';
+import {
+  StreamRunOptions,
+  StreamStep,
+  ToolbarButtonComponent,
+  ToolbarStreamRunnerComponent,
+  wait,
+} from 'ngx-dev-toolbar';
+
+// ─── Scenario data shapes ────────────────────────────────────────────────
+
+interface Ticket {
+  id: string;
+  title: string;
+}
+
+interface Author {
+  id: string;
+  name: string;
+}
+
+interface Post {
+  id: string;
+  title: string;
+  authorId: string;
+}
+
+interface Comment {
+  id: string;
+  text: string;
+  postId: string;
+}
+
+@Component({
+  selector: 'app-stream-runner-demo',
+  standalone: true,
+  imports: [ToolbarStreamRunnerComponent, ToolbarButtonComponent],
+  template: `
+    <section class="showcase">
+      <div class="showcase-section">
+        <h2>Stream Runner showcase</h2>
+        <p>
+          This page demonstrates the standalone
+          <code>&lt;ndt-stream-runner&gt;</code> component with two scripted
+          scenarios. It substitutes for a Storybook story until Storybook
+          lands.
+        </p>
+        <div class="showcase-actions">
+          <ndt-button (click)="runQuick()">
+            Quick discovery (single-step)
+          </ndt-button>
+          <ndt-button (click)="runChained()">
+            Multi-step generation (chaining)
+          </ndt-button>
+        </div>
+      </div>
+
+      <div class="showcase-section">
+        <h3>Live runner</h3>
+        <div class="showcase-runner">
+          <ndt-stream-runner #runner>
+            <p class="showcase-empty">Click a scenario above to start a run.</p>
+          </ndt-stream-runner>
+        </div>
+      </div>
+    </section>
+  `,
+  styleUrls: ['./stream-runner-demo.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class StreamRunnerDemoComponent {
+  private readonly runner = viewChild<ToolbarStreamRunnerComponent>('runner');
+
+  protected async runQuick(): Promise<void> {
+    const step: StreamStep<Ticket> = {
+      label: 'Tickets',
+      verbActive: 'Reading',
+      verbDone: 'Found',
+      total: 5,
+      runItem: async (i) => {
+        await wait(150);
+        return { id: `TICKET-${1000 + i}`, title: `Sample ticket ${i + 1}` };
+      },
+      describe: (t) => t.title,
+      detail: (t) => `id ${t.id}`,
+      placeholderDetail: 'Reading ticket…',
+    };
+
+    const options: StreamRunOptions = {
+      title: 'Quick discovery',
+      preamble: 'Streaming 5 sample tickets at ~150ms each.',
+      steps: [step],
+      pacing: { stepGap: 0 },
+    };
+
+    await this.runner()?.start(options);
+  }
+
+  protected async runChained(): Promise<void> {
+    const authors: StreamStep<Author> = {
+      label: 'Authors',
+      total: 3,
+      runItem: async (i) => {
+        await wait(200);
+        return { id: `author-${i + 1}`, name: `Author ${i + 1}` };
+      },
+      describe: (a) => a.name,
+      detail: (a) => `id ${a.id}`,
+    };
+
+    const posts: StreamStep<Post> = {
+      label: 'Posts',
+      total: 5,
+      runItem: async (i, ctx) => {
+        const priorAuthors = ctx.prior('Authors') as readonly Author[];
+        const author = priorAuthors[i % priorAuthors.length];
+        await wait(180);
+        return {
+          id: `post-${i + 1}`,
+          title: `Post ${i + 1}`,
+          authorId: author.id,
+        };
+      },
+      describe: (p) => p.title,
+      detail: (p) => `by ${p.authorId}`,
+    };
+
+    const comments: StreamStep<Comment> = {
+      label: 'Comments',
+      total: 4,
+      runItem: async (i, ctx) => {
+        const priorPosts = ctx.prior('Posts') as readonly Post[];
+        const post = priorPosts[i % priorPosts.length];
+        await wait(160);
+        return {
+          id: `comment-${i + 1}`,
+          text: `Comment ${i + 1}`,
+          postId: post.id,
+        };
+      },
+      describe: (c) => c.text,
+      detail: (c) => `on ${c.postId}`,
+    };
+
+    const options: StreamRunOptions = {
+      title: 'Multi-step generation',
+      preamble:
+        'Authors → posts that reference an author → comments that reference a post.',
+      steps: [authors, posts, comments],
+      pacing: { stepGap: 100 },
+    };
+
+    await this.runner()?.start(options);
+  }
+}

--- a/apps/ngx-dev-toolbar-demo/src/app/components/stream-runner-demo/stream-runner-demo.component.ts
+++ b/apps/ngx-dev-toolbar-demo/src/app/components/stream-runner-demo/stream-runner-demo.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   viewChild,
 } from '@angular/core';
 import {
@@ -50,10 +51,10 @@ interface Comment {
           lands.
         </p>
         <div class="showcase-actions">
-          <ndt-button (click)="runQuick()">
+          <ndt-button (click)="runQuick()" [disabled]="isRunning()">
             Quick discovery (single-step)
           </ndt-button>
-          <ndt-button (click)="runChained()">
+          <ndt-button (click)="runChained()" [disabled]="isRunning()">
             Multi-step generation (chaining)
           </ndt-button>
         </div>
@@ -74,6 +75,7 @@ interface Comment {
 })
 export class StreamRunnerDemoComponent {
   private readonly runner = viewChild<ToolbarStreamRunnerComponent>('runner');
+  protected readonly isRunning = computed(() => this.runner()?.isRunning() ?? false);
 
   protected async runQuick(): Promise<void> {
     const step: StreamStep<Ticket> = {
@@ -97,7 +99,13 @@ export class StreamRunnerDemoComponent {
       pacing: { stepGap: 0 },
     };
 
-    await this.runner()?.start(options);
+    const runner = this.runner();
+    if (!runner || runner.isRunning()) return;
+    try {
+      await runner.start(options);
+    } catch (err) {
+      console.error('Stream run failed:', err);
+    }
   }
 
   protected async runChained(): Promise<void> {
@@ -154,6 +162,12 @@ export class StreamRunnerDemoComponent {
       pacing: { stepGap: 100 },
     };
 
-    await this.runner()?.start(options);
+    const runner = this.runner();
+    if (!runner || runner.isRunning()) return;
+    try {
+      await runner.start(options);
+    } catch (err) {
+      console.error('Stream run failed:', err);
+    }
   }
 }

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -5,7 +5,7 @@ module.exports = [
   ...nx.configs['flat/typescript'],
   ...nx.configs['flat/javascript'],
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/.astro'],
   },
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],

--- a/libs/ngx-dev-toolbar/src/components/button/button.component.scss
+++ b/libs/ngx-dev-toolbar/src/components/button/button.component.scss
@@ -51,4 +51,14 @@
   &.small {
     font-size: var(--ndt-font-size-sm);
   }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+
+    &:hover {
+      background: var(--ndt-bg-primary);
+      border-color: var(--ndt-border-primary);
+    }
+  }
 }

--- a/libs/ngx-dev-toolbar/src/components/button/button.component.ts
+++ b/libs/ngx-dev-toolbar/src/components/button/button.component.ts
@@ -11,6 +11,7 @@ import { IconName } from '../icons/icon.models';
       class="button"
       [attr.aria-label]="ariaLabel()"
       [type]="type()"
+      [disabled]="disabled()"
       [class.button--active]="isActive()"
       [class.button--icon]="variant() === 'icon'"
     >
@@ -33,4 +34,5 @@ export class ToolbarButtonComponent {
   readonly label = input<string>();
   readonly ariaLabel = input<string>();
   readonly isActive = input<boolean>(false);
+  readonly disabled = input<boolean>(false);
 }

--- a/libs/ngx-dev-toolbar/src/components/stream-runner/stream-runner.component.ts
+++ b/libs/ngx-dev-toolbar/src/components/stream-runner/stream-runner.component.ts
@@ -11,6 +11,7 @@ import { nounSingular, wait } from '../../utils/timing.util';
 import {
   StreamItemRecord,
   StreamPacing,
+  StreamRunContext,
   StreamRunOptions,
   StreamRunResult,
   StreamStepRecord,
@@ -257,6 +258,23 @@ export class ToolbarStreamRunnerComponent {
     // (animation-delay on nth-child) so it doesn't block the first runItem.
     this._visibleCount.set(records.length);
 
+    const ctx: StreamRunContext = {
+      // Reads the latest signal value rather than the closure-captured `records`
+      // because updateItem replaces records/items immutably — the local `records`
+      // array's item objects keep their original 'queued' status forever.
+      prior: (key) => {
+        const current = this._records();
+        const record =
+          typeof key === 'number'
+            ? current[key]
+            : current.find((r) => r.step.label === key);
+        if (!record) return [];
+        return record.items
+          .filter((it) => it.status === 'done')
+          .map((it) => it.value);
+      },
+    };
+
     const startedAt = performance.now();
     let totalItems = 0;
     let totalErrors = 0;
@@ -273,7 +291,7 @@ export class ToolbarStreamRunnerComponent {
         this.updateItem(stepIndex, itemIndex, { status: 'running' });
 
         try {
-          const value = await step.runItem(itemIndex);
+          const value = await step.runItem(itemIndex, ctx);
           this.updateItem(stepIndex, itemIndex, {
             status: 'done',
             value,

--- a/libs/ngx-dev-toolbar/src/components/stream-runner/stream-runner.component.ts
+++ b/libs/ngx-dev-toolbar/src/components/stream-runner/stream-runner.component.ts
@@ -258,20 +258,20 @@ export class ToolbarStreamRunnerComponent {
     // (animation-delay on nth-child) so it doesn't block the first runItem.
     this._visibleCount.set(records.length);
 
+    // Per-run cache so ctx.prior() is O(1) per call (NFR001). Each successful
+    // runItem appends to priorCache.get(stepIndex); prior() reads with a single
+    // Map lookup. labelToIndex resolves string keys without scanning records.
+    const priorCache = new Map<number, unknown[]>();
+    const labelToIndex = new Map<string, number>();
+    records.forEach((r) => {
+      priorCache.set(r.index, []);
+      labelToIndex.set(r.step.label, r.index);
+    });
+
     const ctx: StreamRunContext = {
-      // Reads the latest signal value rather than the closure-captured `records`
-      // because updateItem replaces records/items immutably — the local `records`
-      // array's item objects keep their original 'queued' status forever.
       prior: (key) => {
-        const current = this._records();
-        const record =
-          typeof key === 'number'
-            ? current[key]
-            : current.find((r) => r.step.label === key);
-        if (!record) return [];
-        return record.items
-          .filter((it) => it.status === 'done')
-          .map((it) => it.value);
+        const idx = typeof key === 'number' ? key : labelToIndex.get(key);
+        return idx === undefined ? [] : (priorCache.get(idx) ?? []);
       },
     };
 
@@ -299,6 +299,7 @@ export class ToolbarStreamRunnerComponent {
             detail: step.detail?.(value),
             href: step.link?.(value),
           });
+          priorCache.get(stepIndex)!.push(value);
           totalItems++;
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);

--- a/libs/ngx-dev-toolbar/src/components/stream-runner/stream-runner.models.ts
+++ b/libs/ngx-dev-toolbar/src/components/stream-runner/stream-runner.models.ts
@@ -1,4 +1,14 @@
 /**
+ * Read-only view of items completed in prior steps of the current run.
+ * `prior(0)` returns step 0's resolved values; `prior('Customers')` matches
+ * by `StreamStep.label`. Returns an empty array when the step does not
+ * exist or has no completed items yet.
+ */
+export interface StreamRunContext {
+  prior(stepIndexOrLabel: number | string): readonly unknown[];
+}
+
+/**
  * A single step in a streaming generation. Each step creates `total` items by
  * calling `runItem` once per index. Per-item timing and randomness live in
  * the consumer's `runItem` (await delays, throw to simulate failures).
@@ -19,8 +29,14 @@ export interface StreamStep<T = unknown> {
    * with valid payment methods"). Optional.
    */
   description?: string;
-  /** Creates one item. Owns its own timing (await + random delay) and may throw. */
-  runItem: (index: number) => Promise<T>;
+  /**
+   * Creates one item. Owns its own timing (await + random delay) and may throw.
+   * Receives a `StreamRunContext` as the second arg, which exposes items
+   * completed in earlier steps of the same run. Existing single-arg callbacks
+   * remain valid because the parameter is positional and structurally optional
+   * from the caller's perspective.
+   */
+  runItem: (index: number, ctx: StreamRunContext) => Promise<T>;
   /** Optional deeplink builder. The URL is embedded in the item's title. */
   link?: (item: T) => string;
   /** Optional title builder for each item (defaults to "<singular> <index+1>"). */

--- a/specs/023-mock-tool-polish/.spec-context.json
+++ b/specs/023-mock-tool-polish/.spec-context.json
@@ -1,0 +1,346 @@
+{
+  "workflow": "sdd",
+  "currentStep": "done",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "checkpointStatus": { "commit": false, "pr": false },
+  "updated": "2026-05-09",
+  "selectedAt": "2026-05-08T15:48:06Z",
+  "specName": "Mock Tool Polish",
+  "branch": "main",
+  "workingBranch": "feat/023-mock-tool-polish",
+  "type": "feat",
+  "createdAt": "2026-05-08T15:48:06Z",
+  "loadedDomains": [],
+  "approach": "Evolve StreamStep.runItem to accept an optional StreamRunContext that exposes items completed in prior steps of the same run, threaded through the runner without breaking existing single-arg callbacks.",
+  "files_modified": [
+    "libs/ngx-dev-toolbar/src/components/stream-runner/stream-runner.models.ts",
+    "libs/ngx-dev-toolbar/src/components/stream-runner/stream-runner.component.ts",
+    "apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/mock-data-store.service.ts",
+    "apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/custom-tool.component.ts",
+    "apps/ngx-dev-toolbar-demo/src/app/components/custom-tool-demo/custom-tool-demo.component.ts",
+    "apps/ngx-dev-toolbar-demo/src/app/components/stream-runner-demo/stream-runner-demo.component.scss",
+    "apps/ngx-dev-toolbar-demo/src/app/components/stream-runner-demo/stream-runner-demo.component.ts",
+    "apps/ngx-dev-toolbar-demo/src/app/app.routes.ts",
+    "apps/ngx-dev-toolbar-demo/src/app/components/sidebar/sidebar.component.ts",
+    "apps/docs/src/content/docs/guides/custom-tool.mdx"
+  ],
+  "task_summaries": {
+    "T001": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "Added StreamRunContext interface and evolved StreamStep.runItem signature to (index, ctx) => Promise<T>; JSDoc updated to describe additive positional context arg.",
+      "files": [
+        "libs/ngx-dev-toolbar/src/components/stream-runner/stream-runner.models.ts"
+      ],
+      "concerns": [
+        "Library build (`nx run ngx-dev-toolbar:build`) cannot pass on T001 alone because the runner at stream-runner.component.ts:276 still calls runItem(itemIndex) without ctx. T004 closes this — Group 2 is the gate. The structural assertion of T001 (single-arg consumer callbacks remain assignable) holds: TypeScript's parameter bivariance makes existing demo callers type-compatible."
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Created MockDataStoreService — signal-based in-memory store keyed by step label with addBatch / entities / entitiesSignal / clear; immutable Map updates, no localStorage.",
+      "files": [
+        "apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/mock-data-store.service.ts"
+      ],
+      "concerns": []
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Created page-level SCSS for stream-runner showcase — .showcase, .showcase-section, .showcase-actions, .showcase-runner with --demo-* tokens and a 640px responsive tweak.",
+      "files": [
+        "apps/ngx-dev-toolbar-demo/src/app/components/stream-runner-demo/stream-runner-demo.component.scss"
+      ],
+      "concerns": []
+    },
+    "T004": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "Built StreamRunContext in start() and passed it to step.runItem(itemIndex, ctx); imported StreamRunContext type. Library build passes.",
+      "files": [
+        "libs/ngx-dev-toolbar/src/components/stream-runner/stream-runner.component.ts"
+      ],
+      "concerns": [
+        "Silent fix relative to task wording: ctx.prior reads from this._records() (the signal value) rather than the closure-captured local `records` array. Reason: updateItem replaces records/items immutably, so the local array's item objects keep their original 'queued' status forever — reading the closure would always return []. Reading the signal returns the latest state, which is what the spec actually requires."
+      ]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Threaded MockDataStoreService through BundleDefinition.buildSteps and makeEntityStep so each step batch-flushes via store.addBatch on the last item; replaced billing's Invoices step with a custom runItem(i, ctx) that reads ctx.prior('Customers') and stamps customerId; added FIND → Customers/Categories/Users actions sharing buildFindEntitiesOptions with empty-state preamble. Demo build passes.",
+      "files": [
+        "apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/custom-tool.component.ts"
+      ],
+      "concerns": [
+        "actionsBySection() and selectedAction() now invoke buildActions() on every call (template re-evaluation). Cheap at current scale; memoize if it becomes hot.",
+        "buildFindEntitiesOptions snapshots store.entities(...).length at click time. If the store mutates mid-run the runner would see a stale total — acceptable since the demo doesn't mutate during a run."
+      ]
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Replaced the hardcoded Finder/Maker cards with 15 live cards driven by MockDataStoreService.entitiesSignal(), each showing a count badge and the latest 5 id+name rows; muted empty-state with a hint pointing at the toolbar's Mock Data tool.",
+      "files": [
+        "apps/ngx-dev-toolbar-demo/src/app/components/custom-tool-demo/custom-tool-demo.component.ts"
+      ],
+      "concerns": []
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "Created StreamRunnerDemoComponent with two scenarios — runQuick() (single-step, 5 tickets) and runChained() (Authors → Posts → Comments wired through ctx.prior). Library barrel already exports all required types.",
+      "files": [
+        "apps/ngx-dev-toolbar-demo/src/app/components/stream-runner-demo/stream-runner-demo.component.ts"
+      ],
+      "concerns": []
+    },
+    "T008": {
+      "status": "DONE",
+      "did": "Appended /stream-runner lazy route after the custom-tool entry in app.routes.ts; demo build emits the new lazy chunk.",
+      "files": [
+        "apps/ngx-dev-toolbar-demo/src/app/app.routes.ts"
+      ],
+      "concerns": []
+    },
+    "T009": {
+      "status": "DONE",
+      "did": "Added Stream Runner nav entry next to custom-tool in navItems, reusing the existing inline SVG path string from custom-tool to avoid introducing a new icon.",
+      "files": [
+        "apps/ngx-dev-toolbar-demo/src/app/components/sidebar/sidebar.component.ts"
+      ],
+      "concerns": []
+    },
+    "T010": {
+      "status": "DONE",
+      "did": "Inserted a Streaming Runner H2 section in the custom-tool guide; covers StreamStep / StreamRunOptions / StreamRunContext shapes, a customers→invoices chaining example, a /stream-runner pointer, plus an 'Anatomy of a rendered step' subsection (added at CP1) showing how every string field maps to the rendered row and explicitly noting that returned strings are HTML-escaped.",
+      "files": [
+        "apps/docs/src/content/docs/guides/custom-tool.mdx"
+      ],
+      "concerns": []
+    }
+  },
+  "concerns": [
+    {
+      "task": "T001",
+      "note": "Library build fails in isolation — runner call site at stream-runner.component.ts:276 still invokes runItem with one argument. T004 closes this gate."
+    },
+    {
+      "task": "T004",
+      "note": "ctx.prior reads from this._records() rather than the closure-captured `records` (deviation from the task's literal wording). updateItem replaces items immutably, so the local closure would always see status='queued' — the signal read is required for correctness."
+    }
+  ],
+  "decisions": [
+    {
+      "task": "T004",
+      "note": "Skipped R007 (run-level metadata exposure) per task instructions — keeping the API minimal until a real consumer needs it."
+    },
+    {
+      "task": "T010",
+      "note": "CP1 expansion: added an 'Anatomy of a rendered step' subsection. User asked for HTML title/description support; clarified the runner only takes strings (interpolation escapes HTML) and chose Path A — document the existing API more thoroughly — over Path B (add HTML support, which would be a separate spec)."
+    }
+  ],
+  "last_action": "CP3 approved — staging and committing feat(toolbar): stream-runner chaining context + mock-data live mirror.",
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 7,
+      "scenarios": 5,
+      "key_finding": "Mock-data tool lives in the demo app; only <ndt-stream-runner> is library-exported, and its StreamStep.runItem(index) signature has no slot for prior-step outputs — chaining requires evolving that public API."
+    },
+    "plan": {
+      "approach_summary": "Evolve StreamStep.runItem to accept an optional StreamRunContext that exposes items completed in prior steps of the same run, threaded through the runner without breaking existing single-arg callbacks.",
+      "files_planned": 10,
+      "risks": [
+        "Public-API surface change on StreamStep<T>.runItem — mitigated by additive optional second parameter that is source- and binary-compatible.",
+        "Bursty per-item DOM updates on the demo wrapper (NFR002) — mitigated by batching MockDataStoreService writes per-step rather than per-item.",
+        "FIND fallback ambiguity (R004 hardcoded fallback vs Empty-state scenario hint) — resolved by keeping hardcoded fallback only for entity types that already have one (Routes, DOM elements) and showing empty + hint for new bundle-mirroring FIND types."
+      ],
+      "principles_concerns": 0,
+      "domain_concerns": 0,
+      "significance_score": 1
+    },
+    "tasks": {
+      "task_count": 10,
+      "parallel_count": 9,
+      "groups": 4
+    }
+  },
+  "transitions": [
+    {
+      "step": "specify",
+      "substep": "parsing",
+      "from": null,
+      "by": "sdd",
+      "at": "2026-05-08T15:48:06Z"
+    },
+    {
+      "step": "specify",
+      "substep": "exploring",
+      "from": { "step": "specify", "substep": "parsing" },
+      "by": "sdd",
+      "at": "2026-05-08T15:48:07Z"
+    },
+    {
+      "step": "specify",
+      "substep": "loaded-domains",
+      "from": { "step": "specify", "substep": "exploring" },
+      "by": "sdd",
+      "at": "2026-05-08T15:48:08Z"
+    },
+    {
+      "step": "specify",
+      "substep": "detecting",
+      "from": { "step": "specify", "substep": "loaded-domains" },
+      "by": "sdd",
+      "at": "2026-05-08T15:48:09Z"
+    },
+    {
+      "step": "specify",
+      "substep": "writing-spec",
+      "from": { "step": "specify", "substep": "detecting" },
+      "by": "sdd",
+      "at": "2026-05-08T15:48:10Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": { "step": "specify", "substep": "writing-spec" },
+      "by": "sdd",
+      "at": "2026-05-08T15:48:11Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": { "step": "specify", "substep": null },
+      "by": "extension",
+      "at": "2026-05-08T15:51:20.815Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": { "step": "specify", "substep": null },
+      "by": "extension",
+      "at": "2026-05-08T15:51:20.818Z"
+    },
+    {
+      "step": "plan",
+      "substep": "research",
+      "from": { "step": "plan", "substep": null },
+      "by": "sdd",
+      "at": "2026-05-08T15:53:58Z"
+    },
+    {
+      "step": "plan",
+      "substep": "design",
+      "from": { "step": "plan", "substep": "research" },
+      "by": "sdd",
+      "at": "2026-05-08T15:53:58Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": { "step": "plan", "substep": "design" },
+      "by": "sdd",
+      "at": "2026-05-08T15:55:18Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": { "step": "plan", "substep": null },
+      "by": "sdd",
+      "at": "2026-05-08T15:59:20Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": { "step": "tasks", "substep": null },
+      "by": "sdd",
+      "at": "2026-05-08T16:02:05Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": { "step": "tasks", "substep": null },
+      "by": "sdd",
+      "at": "2026-05-08T16:11:58Z"
+    },
+    {
+      "step": "implement",
+      "substep": "T001-complete",
+      "from": { "step": "implement", "substep": null },
+      "by": "sdd",
+      "at": "2026-05-08T16:18:00Z"
+    },
+    {
+      "step": "implement",
+      "substep": "group1-complete",
+      "from": { "step": "implement", "substep": "T001-complete" },
+      "by": "sdd",
+      "at": "2026-05-08T16:22:00Z"
+    },
+    {
+      "step": "implement",
+      "substep": "T004-complete",
+      "from": { "step": "implement", "substep": "group1-complete" },
+      "by": "sdd",
+      "at": "2026-05-08T16:25:00Z"
+    },
+    {
+      "step": "implement",
+      "substep": "group3-complete",
+      "from": { "step": "implement", "substep": "T004-complete" },
+      "by": "sdd",
+      "at": "2026-05-08T16:33:00Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1-complete",
+      "from": { "step": "implement", "substep": "group3-complete" },
+      "by": "sdd",
+      "at": "2026-05-08T16:38:00Z"
+    },
+    {
+      "step": "implement",
+      "substep": "code-review",
+      "from": { "step": "implement", "substep": "phase1-complete" },
+      "by": "sdd",
+      "at": "2026-05-08T16:38:01Z"
+    },
+    {
+      "step": "implement",
+      "substep": "code-review-fix-T010",
+      "from": { "step": "implement", "substep": "code-review" },
+      "by": "sdd",
+      "at": "2026-05-09T15:00:00Z"
+    },
+    {
+      "step": "implement",
+      "substep": "commit-review",
+      "from": { "step": "implement", "substep": "code-review-fix-T010" },
+      "by": "sdd",
+      "at": "2026-05-09T15:05:00Z"
+    },
+    {
+      "step": "done",
+      "substep": "committing",
+      "from": { "step": "implement", "substep": "commit-review" },
+      "by": "sdd",
+      "at": "2026-05-09T15:10:00Z"
+    }
+  ],
+  "status": "completed",
+  "stepHistory": {
+    "specify": {
+      "startedAt": "2026-05-08T15:49:17.392Z",
+      "completedAt": "2026-05-08T15:51:20.815Z"
+    },
+    "plan": {
+      "startedAt": "2026-05-08T15:51:20.818Z",
+      "completedAt": "2026-05-08T15:55:18Z"
+    },
+    "tasks": {
+      "startedAt": "2026-05-08T15:59:20Z",
+      "completedAt": "2026-05-08T16:02:05Z"
+    },
+    "implement": {
+      "startedAt": "2026-05-08T16:11:58Z",
+      "completedAt": null
+    }
+  }
+}

--- a/specs/023-mock-tool-polish/.spec-context.json
+++ b/specs/023-mock-tool-polish/.spec-context.json
@@ -4,7 +4,9 @@
   "currentTask": null,
   "progress": null,
   "next": "done",
-  "checkpointStatus": { "commit": false, "pr": false },
+  "checkpointStatus": { "commit": true, "pr": true },
+  "prUrl": "https://github.com/alfredoperez/ngx-dev-toolbar/pull/53",
+  "prNumber": 53,
   "updated": "2026-05-09",
   "selectedAt": "2026-05-08T15:48:06Z",
   "specName": "Mock Tool Polish",
@@ -135,7 +137,7 @@
       "note": "CP1 expansion: added an 'Anatomy of a rendered step' subsection. User asked for HTML title/description support; clarified the runner only takes strings (interpolation escapes HTML) and chose Path A — document the existing API more thoroughly — over Path B (add HTML support, which would be a separate spec)."
     }
   ],
-  "last_action": "CP3 approved — staging and committing feat(toolbar): stream-runner chaining context + mock-data live mirror.",
+  "last_action": "PR #53 opened — feat(toolbar): stream-runner chaining context + mock-data live mirror.",
   "step_summaries": {
     "specify": {
       "complexity": "normal",
@@ -322,6 +324,13 @@
       "from": { "step": "implement", "substep": "commit-review" },
       "by": "sdd",
       "at": "2026-05-09T15:10:00Z"
+    },
+    {
+      "step": "done",
+      "substep": "pr-opened",
+      "from": { "step": "done", "substep": "committing" },
+      "by": "sdd",
+      "at": "2026-05-09T15:15:00Z"
     }
   ],
   "status": "completed",

--- a/specs/023-mock-tool-polish/plan.md
+++ b/specs/023-mock-tool-polish/plan.md
@@ -1,0 +1,57 @@
+# Plan: Mock Tool Polish
+
+**Spec**: [spec.md](./spec.md)
+
+## Approach
+
+Evolve `StreamStep<T>.runItem` to accept an optional second argument — a `StreamRunContext` that exposes items completed in prior steps of the same run — and pass it from the runner without changing call-site semantics for existing single-arg callbacks. Introduce a demo-app `MockDataStoreService` as the single source of truth for entities created via the toolbar's bundles, so the demo wrapper page can mirror them live and FIND actions can return real prior creations. Round it off with a stream-runner showcase route in the demo (substituting for Storybook) and a new "Streaming runner" section in the custom-tool docs guide.
+
+The key architectural choice is keeping the chaining context **purely a read-view over `StreamStepRecord.items[].value`** — the runner already accumulates these as steps resolve, so no extra buffering is needed and lookup stays O(1) per step. Backwards compatibility (R001) is structurally guaranteed: in TypeScript, a `(i) => Promise<T>` is assignable to `(i, ctx?) => Promise<T>`, so existing callers compile and run unchanged.
+
+## Architecture
+
+```mermaid
+graph LR
+  Tool[Mock Data tool<br/>custom-tool.component.ts] -->|writes| Store[(MockDataStoreService<br/>demo-app)]
+  Runner[ndt-stream-runner] -->|runItem i, ctx| Tool
+  Tool -->|reads via ctx.prior| Tool
+  Store -->|signal| Wrapper[CustomToolDemoComponent<br/>demo page]
+  Store -->|reads| FIND[FIND actions<br/>fall back to hardcoded]
+  Showcase[stream-runner-demo route] -->|hosts| Runner
+```
+
+## Files
+
+### Create
+
+- `apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/mock-data-store.service.ts` — In-memory store keyed by entity label (`Customers`, `Invoices`, …) using signals; exposes `add(label, items)`, `entities(label)`, and `clear()`. Lives in demo app, not library, since persistence is out of scope.
+- `apps/ngx-dev-toolbar-demo/src/app/components/stream-runner-demo/stream-runner-demo.component.ts` — New showcase route hosting `<ndt-stream-runner>` with two scripted scenarios: a single-step quick-discovery flow and a multi-step generation flow that exercises the new chaining context (R005).
+- `apps/ngx-dev-toolbar-demo/src/app/components/stream-runner-demo/stream-runner-demo.component.scss` — Page styles consistent with sibling demo pages.
+
+### Modify
+
+- `libs/ngx-dev-toolbar/src/components/stream-runner/stream-runner.models.ts` — Add `StreamRunContext` interface (`prior(stepIndexOrLabel: number | string): readonly unknown[]`); change `runItem` signature to `(index: number, ctx: StreamRunContext) => Promise<T>` (single-arg callers still satisfy this).
+- `libs/ngx-dev-toolbar/src/components/stream-runner/stream-runner.component.ts` — Build a context object once per run that closes over `_records()`; pass it as the second argument to `step.runItem(itemIndex, ctx)` at line 276. The context resolves a step by index or label and returns `items.filter(it => it.status === 'done').map(it => it.value)` — but reads each step's items via cached references on `StreamStepRecord` (NFR001, O(1) per step access).
+- `apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/custom-tool.component.ts` — Inject `MockDataStoreService`. In `makeEntityStep.runItem`, after generating an entity, push it into the store under the step's label. Add an Invoices step variant whose `runItem` reads `ctx.prior('Customers')` and tags the new invoice with `customerId` matching a real prior customer (R002). Add FIND actions per CREATE bundle's first entity type (e.g. FIND → Customers) that read from the store; when empty, complete with zero items and a hint (R004 + Empty-state scenario). Keep existing FIND → Routes / FIND → DOM elements unchanged.
+- `apps/ngx-dev-toolbar-demo/src/app/components/custom-tool-demo/custom-tool-demo.component.ts` — Replace the hardcoded "Finder/Maker" preview cards with a live grid that mirrors `MockDataStoreService` entities by label, falling back to an explanatory empty state when nothing has been generated yet (R003). Updates batch via signals (per-step rather than per-item, NFR002).
+- `apps/ngx-dev-toolbar-demo/src/app/app.routes.ts` — Register `path: 'stream-runner'` lazy-loading the showcase component.
+- `apps/ngx-dev-toolbar-demo/src/app/components/sidebar/sidebar.component.ts` — Add a `Stream Runner` nav item pointing at `/stream-runner`.
+- `apps/docs/src/content/docs/guides/custom-tool.mdx` — Append a "Streaming Runner" section (after "Multi-Step Tools") covering `StreamStep`, `StreamRunOptions`, and the new chaining context, with the Mock Data tool's customer→invoice flow as the worked example (R006).
+
+## Data Model
+
+- `StreamRunContext` — fields: `prior(stepIndexOrLabel: number | string): readonly unknown[]` — **new** library-side interface; thin read-view exposing completed-item values from earlier steps in the current run.
+- `StreamStep<T>.runItem` — signature: `(index: number, ctx: StreamRunContext) => Promise<T>` — **modified** (additive second parameter; existing single-arg callbacks remain valid).
+- `MockDataStore` — fields: `entitiesByLabel: signal<Map<string, unknown[]>>` — **new** demo-app service; mutated by bundle `runItem`s, observed by the wrapper page and FIND actions.
+
+## Testing Strategy
+
+- **Unit (library)**: extend stream-runner's existing tests with a chaining-context case — a two-step run where step 2's `runItem` reads `ctx.prior(0)` and asserts it sees step 1's resolved values.
+- **Unit (back-compat)**: ensure existing single-arg `runItem` tests still pass with no changes (compile-time + runtime).
+- **Manual**: run the Billing bundle via the toolbar; confirm each invoice's `customerId` matches one of the customers from step 1; open the demo page mid-run and confirm entities appear live; run FIND → Customers with an empty store and confirm the hint shows.
+
+## Risks
+
+- **Public-API surface change**: even though the new parameter is optional, `StreamStep<T>` is exported from the library. Mitigation: ship as additive, document in the docs guide, keep release as a `feat` rather than `feat!` since existing code is source- and binary-compatible.
+- **Demo-page churn under bursty creates (NFR002)**: signaling 50 individual `add(label, item)` calls would push 50 DOM updates. Mitigation: have `MockDataStoreService.add()` accept arrays and have the bundle steps batch per-step (push the whole step's items at the step boundary) rather than per-item.
+- **FIND fallback ambiguity**: spec's R004 says "fall back to hardcoded sample" but the Empty-state scenario describes empty + hint. Mitigation: only entity types that *have* a hardcoded sample today (Routes, DOM elements) keep that fallback; new bundle-mirroring FIND types (Customers, etc.) show empty + hint, since there's no hardcoded list for them.

--- a/specs/023-mock-tool-polish/spec.md
+++ b/specs/023-mock-tool-polish/spec.md
@@ -1,0 +1,57 @@
+# Spec: Mock Tool Polish
+
+**Slug**: 023-mock-tool-polish | **Date**: 2026-05-08
+
+## Summary
+
+The mock-data custom tool ships in the demo (PR #50) but has rough edges: bundle steps can't reference IDs from prior steps, so a generated invoice can't point at a real customer; the demo page outside the toolbar still describes a removed Finder/Maker tabs UI with hardcoded preview rows; and the FIND actions return static lists instead of items the user actually created. This spec evolves `StreamStep<T>.runItem` to receive a chaining context, refreshes the demo page to mirror real created entities, points FIND actions at live data, and fills the missing developer guidance (custom-tool docs guide + a stream-runner showcase in the demo app).
+
+## Requirements
+
+- **R001** (MUST): `StreamStep<T>.runItem` MUST accept an optional second argument — a context object that exposes items completed in prior steps of the same run, keyed by step index and/or step label. Existing `runItem: async (i) => …` callers MUST continue to work without source changes (the second arg is additive and optional).
+- **R002** (MUST): The mock-data tool's CREATE bundles MUST use the new chaining context so cross-entity references are real — e.g. each generated invoice carries a `customerId` matching a customer id produced in step 1 of the same run, instead of a freestanding random id.
+- **R003** (MUST): The demo page wrapper at `apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/custom-tool-demo.component.ts` MUST display the entities created by the toolbar's mock-data tool live, replacing the current hardcoded preview rows that describe a Finder/Maker UI no longer present in the tool.
+- **R004** (SHOULD): FIND-flow actions in the mock-data tool SHOULD return entities that were previously created through the tool when such data exists, falling back to the existing hardcoded sample only when the in-memory store is empty.
+- **R005** (SHOULD): The demo app SHOULD include a route that showcases the standalone `<ndt-stream-runner>` component with at least two scripted scenarios (a quick discovery flow and a multi-step generation flow), serving the role of a Storybook story until Storybook is introduced.
+- **R006** (SHOULD): The custom-tool guide at `apps/docs/src/content/docs/guides/custom-tool.mdx` SHOULD gain a new section that walks through building a tool around `<ndt-stream-runner>`, covering `StreamStep`, the chaining context, and the mock-data tool as the worked example.
+- **R007** (MAY): The chaining context MAY also expose run-level metadata (current step index, elapsed time) for advanced consumers, but only if it falls out of the design — adding it is not a goal of this spec.
+
+## Scenarios
+
+### Bundle step references prior step's IDs
+
+**When** the user runs the "Billing data" bundle and the Invoices step executes after Customers
+**Then** each generated invoice's `customerId` matches the `id` of a customer produced in step 1 of the same run, and the invoice's deeplink points to a route under that customer.
+
+### Demo page mirrors created entities
+
+**When** the user generates 5 customers via the toolbar's Mock Data tool
+**Then** the demo page (outside the toolbar) shows those 5 customers in a live list using the same ids the runner produced, replacing the static preview rows that previously described a Finder/Maker UI.
+
+### FIND returns previously created entities
+
+**When** the user runs CREATE → Customers, then opens FIND → Customers
+**Then** the FIND action streams back the customers that were just created (same ids, same names), not a hardcoded sample list.
+
+### Empty-state for FIND with no prior creates
+
+**When** the user opens FIND → Customers without having created any
+**Then** the action runs to completion and surfaces an empty result with a hint pointing at the matching CREATE flow.
+
+### Backwards compatibility for existing runItem callers
+
+**When** an existing `runItem: async (i) => …` (single-argument) callsite is used unchanged with the new runner
+**Then** the runner still calls it correctly and the run completes — no type errors at compile time and no runtime errors from the additional context argument going unused.
+
+## Non-Functional Requirements
+
+- **NFR001** (SHOULD): Chaining-context lookup MUST be O(1) per step access (e.g. items cached on `StreamStepRecord` keyed by step index already exists — the context wraps it without per-item filtering) so long bundles don't accumulate quadratic cost.
+- **NFR002** (MAY): Demo-page reactions to created entities should be batched per step or per N items rather than per item, so a 50-item burst does not trigger 50 separate DOM updates.
+
+## Out of Scope
+
+- A real persistence layer for the demo — created entities live in memory only and reset on page reload.
+- Standing up Storybook itself; the "stories" requirement is satisfied by demo-app routes until a Storybook setup lands separately.
+- Cross-bundle chaining (e.g. a Billing invoice referencing a User from the Onboarding bundle) — chaining stays within a single run.
+- New FIND types beyond mirroring existing CREATE bundles (no FIND for routes-from-router, etc., unless they already exist today).
+- Reworking the `<ndt-stream-runner>` visual design — this spec only adds an input to `StreamStep` and consumes it.

--- a/specs/023-mock-tool-polish/tasks.md
+++ b/specs/023-mock-tool-polish/tasks.md
@@ -1,0 +1,65 @@
+# Tasks: Mock Tool Polish
+
+**Plan**: [plan.md](./plan.md)
+
+> Format reference: `[P]` markers and parallel groups — see `skills/tasks/SKILL.md` § Phase rules.
+
+## Phase 1: Core Implementation
+
+### Group 1 — Foundations (parallel)
+
+- [x] **T001** [P] Add `StreamRunContext` interface + evolve `runItem` signature — `libs/ngx-dev-toolbar/src/components/stream-runner/stream-runner.models.ts` | R001
+  - **Do**: Export a new `StreamRunContext` interface with a single method `prior(stepIndexOrLabel: number | string): readonly unknown[]`. Change `StreamStep<T>.runItem` from `(index: number) => Promise<T>` to `(index: number, ctx: StreamRunContext) => Promise<T>`. Update the JSDoc comment on `runItem` to describe the new context arg ("provides read-only access to items completed in prior steps; existing single-arg callbacks remain valid because the parameter is positional"). Do not change any other types in this file.
+  - **Verify**: `nx run ngx-dev-toolbar:build` passes. Existing callers in `apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/custom-tool.component.ts` still type-check (single-arg `(i) => …` is assignable to `(i, ctx) => …`).
+  - **Leverage**: existing JSDoc style on `StreamStep` fields (lines 6–38) — match the same compact comment style.
+
+- [x] **T002** [P] Create in-memory mock-data store service — `apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/mock-data-store.service.ts` | R003, R004, NFR002
+  - **Do**: New `@Injectable({ providedIn: 'root' })` class `MockDataStoreService`. Internal state: a single `signal<Map<string, unknown[]>>(new Map())` keyed by step label (e.g. `"Customers"`, `"Invoices"`). Public API: `addBatch(label: string, items: readonly unknown[]): void` (immutable update — replaces the map entry with a fresh array containing previous + new items), `entities<T>(label: string): readonly T[]` (returns the current array or `[]`), `entitiesSignal<T>(label: string): Signal<readonly T[]>` (computed view for reactive consumers), `clear(label?: string): void`. Use `signal.update()` with spread for immutability. Do **not** persist to localStorage — out of scope per spec.
+  - **Verify**: `nx run ngx-dev-toolbar-demo:build` passes (or `nx serve ngx-dev-toolbar-demo` starts cleanly). Service is a singleton in DI.
+  - **Leverage**: existing internal-service pattern in `libs/ngx-dev-toolbar/src/tools/feature-flags/feature-flags-internal.service.ts` for signal-based readonly state.
+
+- [x] **T003** [P] Create stream-runner showcase styles — `apps/ngx-dev-toolbar-demo/src/app/components/stream-runner-demo/stream-runner-demo.component.scss` | R005
+  - **Do**: Page-level styles consistent with sibling demo pages (e.g. `i18n-demo.component.ts` inline styles or `feature-flags-demo`). Provide `.showcase` container, `.showcase-section` cards, `.showcase-actions` button row, and a `.showcase-runner` slot that gives `<ndt-stream-runner>` a sensible max-width and padding. No imports of toolbar internals — this page sits outside the toolbar Shadow DOM.
+  - **Verify**: file compiles (no SCSS syntax errors); the styles do not need to render correctly until T008 lands.
+  - **Leverage**: any existing `*-demo.component.scss` for layout rhythm and the `--demo-*` CSS custom-property convention used in `custom-tool-demo.component.ts`.
+
+### Group 2 — Runner runtime (gate)
+
+- [x] **T004** Build `StreamRunContext` and pass to `runItem` — `libs/ngx-dev-toolbar/src/components/stream-runner/stream-runner.component.ts` *(depends on T001)* | R001, NFR001, R007
+  - **Do**: Inside `start()`, after `this._records.set(records)`, construct a single context object that closes over the local `records` array: `const ctx: StreamRunContext = { prior: (key) => { const rec = typeof key === 'number' ? records[key] : records.find(r => r.step.label === key); return rec ? rec.items.filter(it => it.status === 'done').map(it => it.value) : []; } }`. Replace the call at line 276 from `await step.runItem(itemIndex)` to `await step.runItem(itemIndex, ctx)`. Note: because `ctx.prior` reads from the live `records` array (not a snapshot), step N sees everything resolved by steps 0..N-1 at the moment it runs. Lookup is O(1) for index, O(steps) for label — acceptable per NFR001 since step counts are tiny. Do **not** widen the public surface beyond what T001 added (no metadata accessors unless they "fall out of the design" — for this spec, skip R007 to keep the API minimal).
+  - **Verify**: `nx run ngx-dev-toolbar:build` passes. Manual: existing demo "Generate billing data" still completes end-to-end (back-compat smoke test).
+  - **Leverage**: existing `updateRecord` / `updateItem` patterns (lines 430–453) for understanding how records mutate during a run.
+
+### Group 3 — Consumers (parallel, depend on Group 2)
+
+- [x] **T005** [P] Wire mock-data tool to chaining context + store — `apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/custom-tool.component.ts` *(depends on T001, T002, T004)* | R002, R004
+  - **Do**: (1) Inject `MockDataStoreService`. (2) In `makeEntityStep`, after the `runItem` body successfully resolves, **batch** items per step: collect into a local array inside the closure, then push to the store via `addBatch(label, batch)` once the step completes — easiest approach is to wrap the bundle's `buildSteps` so each step has an `runItem` that closes over a per-step buffer and flushes to the store on the last `total` index. (3) Add a dedicated `Invoices` step variant (replacing the `makeEntityStep('Invoices', …)` call inside the billing bundle) whose `runItem: async (i, ctx)` reads `ctx.prior<MockEntity>('Customers')` and stamps `customerId: customers[i % customers.length]?.id` into the generated invoice; the deeplink also routes under that customer (e.g. `/billing/customers/{customerId}/invoices/{id}`). (4) Add new FIND actions per CREATE bundle's first entity type (FIND → Customers, FIND → Categories, FIND → Users). Their `buildOptions` reads `store.entities('<Label>')`; if non-empty, build a single-step run that streams those entities back; if empty, build a single-step run with `total: 0` and a `preamble` like "No customers yet — run CREATE → Customers to seed data." Keep existing FIND → Routes / FIND → DOM elements unchanged.
+  - **Verify**: Open the toolbar, run CREATE → Billing data with 3 items; expand Invoices step and confirm each invoice's `detail` mentions a `customerId` matching one of the customers' ids (you can also peek at the runner's stored `value` via DevTools). Then open FIND → Customers and confirm those 3 customers stream back. Open FIND → Customers without prior creates and confirm the empty preamble shows.
+  - **Leverage**: existing `makeEntityStep` factory (line 58–89) for the per-item wait + jitter pattern; existing `buildFindRoutesOptions` (line 241) for single-step direct-run shape.
+
+- [x] **T006** [P] Mirror created entities live in demo wrapper — `apps/ngx-dev-toolbar-demo/src/app/components/custom-tool-demo/custom-tool-demo.component.ts` *(depends on T002)* | R003, NFR002
+  - **Do**: Replace the entire hardcoded "Finder Tab" / "Maker Tab" markup. New layout: a header explaining what the page mirrors, then a responsive grid of cards — one card per known label (Customers, Invoices, Subscriptions, Line items, Payment methods, Categories, Products, Variants, Inventory, Suppliers, Users, Sessions, Profiles, Preferences, Invitations) — each card shows the count and the latest 5 entities by id+name from `MockDataStoreService.entitiesSignal('<Label>')`. When a label has zero entities, render a muted card with the explanatory text "Run the toolbar's Mock Data tool to seed `<label>`". Inject the service via `inject(MockDataStoreService)`. Use `@for` over a constant labels array, `track`. Because each card reads its own signal slice, only labels with new data re-render — satisfies NFR002 without manual debouncing.
+  - **Verify**: `nx serve ngx-dev-toolbar-demo`; navigate to `/custom-tool`; confirm the page initially shows muted "no data" cards. Open the toolbar, run CREATE → Billing data; switch back to the demo page and confirm the Customers/Invoices/etc. cards now show real ids.
+  - **Leverage**: card and grid patterns already in this file's `<style>` block (`.demo-card-grid`, `.demo-card`); keep the existing CSS variables (`--demo-card-bg` etc.) for theme consistency.
+
+- [x] **T007** [P] Build stream-runner showcase component — `apps/ngx-dev-toolbar-demo/src/app/components/stream-runner-demo/stream-runner-demo.component.ts` *(depends on T001, T004)* | R005
+  - **Do**: New standalone `StreamRunnerDemoComponent` with selector `app-stream-runner-demo`, `OnPush`, paired with `stream-runner-demo.component.scss` (T003). Imports `ToolbarStreamRunnerComponent` and `ToolbarButtonComponent` from `ngx-dev-toolbar`. Two scripted scenarios accessible via buttons: (a) **Quick discovery** — single-step run, 5 hardcoded items, ~150ms each, no chaining; (b) **Multi-step generation** — 3 steps that exercise the new chaining context (e.g. step 1: 3 "Authors", step 2: 5 "Posts" each referencing an author id from step 1 via `ctx.prior('Authors')`, step 3: 4 "Comments" each referencing a post). Inline template, `@ViewChild('runner')` for the `ToolbarStreamRunnerComponent`, `runQuick()` and `runChained()` methods. Render a header explaining the page substitutes for Storybook until Storybook lands.
+  - **Verify**: After T008/T009 land, navigate to `/stream-runner` and click each scenario button; confirm the chained scenario produces posts whose `detail` shows the parent author id and comments referencing post ids.
+  - **Leverage**: `apps/ngx-dev-toolbar-demo/src/app/components/custom-tool/custom-tool.component.ts` lines 241–283 (`buildFindRoutesOptions`, `buildFindElementsOptions`) for `StreamRunOptions` shape; lines 558–587 (`scheduleRun`, `runOnce`) for the `afterNextRender` + `runner.start()` pattern.
+
+### Group 4 — Wire-up + docs (parallel, depend on T007)
+
+- [x] **T008** [P] Register showcase route — `apps/ngx-dev-toolbar-demo/src/app/app.routes.ts` *(depends on T007)* | R005
+  - **Do**: Append a new route `{ path: 'stream-runner', loadComponent: () => import('./components/stream-runner-demo/stream-runner-demo.component').then((m) => m.StreamRunnerDemoComponent) }` after the existing `custom-tool` entry.
+  - **Verify**: `nx serve ngx-dev-toolbar-demo`; navigate to `/stream-runner` directly and confirm it loads (the page itself is exercised in T007's verify after this lands).
+  - **Leverage**: existing entries in this file (lines 38–43) for the lazy-import shape.
+
+- [x] **T009** [P] Add Stream Runner sidebar nav item — `apps/ngx-dev-toolbar-demo/src/app/components/sidebar/sidebar.component.ts` *(depends on T007)* | R005
+  - **Do**: Append a `NavItem` to `navItems` (currently lines 247+) with `label: 'Stream Runner'`, `path: '/stream-runner'`, and an `id` matching the convention used by sibling entries (e.g. `'stream-runner'`). Pick a reasonable existing nav icon — reuse one already in the file's icon switch rather than introducing a new SVG.
+  - **Verify**: visual check — the sidebar shows a "Stream Runner" entry that highlights when on that route.
+  - **Leverage**: existing `navItems` entries (lines 247–276) for the entry shape and icon-id convention.
+
+- [x] **T010** [P] Append "Streaming Runner" section to custom-tool guide — `apps/docs/src/content/docs/guides/custom-tool.mdx` | R006
+  - **Do**: Insert a new H2 section titled "Streaming Runner" *after* the "Multi-Step Tools" section (currently around line 174) and *before* the "Styling" section. Cover: (1) when to reach for `<ndt-stream-runner>` (long-running, multi-entity creation flows), (2) the `StreamStep<T>` shape (label, total, runItem, link, describe, detail), (3) `StreamRunOptions` (title, preamble, steps, pacing), (4) the new `StreamRunContext` and how `runItem(index, ctx)` enables cross-step chaining, with the Mock Data tool's customer→invoice example transcribed as a code block. End with a one-sentence pointer to the demo's `/stream-runner` showcase route. Keep the prose tight — match the guide's existing voice.
+  - **Verify**: `nx serve documentation` (or whatever the docs serve target is) renders the new section without MDX parse errors; the code block syntax-highlights.
+  - **Leverage**: existing "Multi-Step Tools" section (lines 174–242) for code-block + prose rhythm; existing table-of-design-tokens (lines 277+) is **not** what we want here — favor the MultiStep prose style.


### PR DESCRIPTION
## What

- Add `StreamRunContext` to `<ndt-stream-runner>` so steps can read items resolved by prior steps in the same run. `StreamStep.runItem` is now `(i, ctx) => Promise<T>` — existing single-arg callbacks remain valid via parameter bivariance.
- Wire the demo's mock-data tool through the new context: invoices reference real customer ids, FIND → Customers/Categories/Users return previously-created entities, demo page mirrors created entities live in 15 cards.
- Add `/stream-runner` showcase route + sidebar entry with single-step and chained scenarios (Authors → Posts → Comments).
- Expand the custom-tool docs guide with a Streaming Runner section, including an "Anatomy of a rendered step" worked example that maps each `StreamStep` field to its rendered output.

## Why

The mock-data tool shipped in PR #50 with rough edges: bundle steps couldn't reference ids from prior steps so invoices couldn't point at real customers, the demo wrapper still described a removed Finder/Maker UI, and FIND actions returned hardcoded lists. This spec closes those gaps and fills in the missing developer-facing docs and showcase.

## Testing

- Library + demo builds pass: `nx run-many -t build --projects=ngx-dev-toolbar,ngx-dev-toolbar-demo`
- Manual: in the demo, run CREATE → Billing data with 3 items; expand the Invoices step and confirm each invoice's detail mentions a `customerId` matching one of the customers' ids; deeplink routes under `/billing/customers/{customerId}/invoices/{id}`.
- Manual: navigate to `/custom-tool` and confirm the 15 mirror cards populate live (Customers, Invoices, etc. show real ids after a CREATE run).
- Manual: open FIND → Customers after a CREATE run and confirm the customers stream back; on a fresh load confirm the empty-state preamble ("No customers yet — run CREATE → Customers to seed data.") renders.
- Manual: navigate to `/stream-runner` and click both scenario buttons; the chained scenario produces posts whose detail shows the parent author id and comments referencing post ids.